### PR TITLE
Added shader pipeline class and associated builder

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -36,3 +36,5 @@ export { default as If } from './if'
 export { default as Block } from './block'
 export { default as While } from './while'
 export { default as DoWhile } from './dowhile'
+export { default as ShaderPipelineBuilder } from './shaderpipelinebuilder';
+export { default as ShaderPipeline } from './shaderpipeline';

--- a/src/shader.ts
+++ b/src/shader.ts
@@ -20,18 +20,18 @@ export default class Shader {
             .join('\n');
     }
 
-    public inputs(): Type[] {
+    public inputs(): { kind: Type, name: string }[] {
         return [...this.main.dependencies()]
             .filter(dependency => dependency.qualifier == Qualifier.In
                 || dependency.qualifier == Qualifier.InOut
                 || dependency.qualifier == Qualifier.Attribute)
-            .map(dependency => dependency.kind);
+            .map(dependency => ({ kind: dependency.kind, name: dependency.name }));
     }
 
-    public outputs(): Type[] {
+    public outputs(): { kind: Type, name: string }[] {
         return [...this.main.dependencies()]
             .filter(dependency => dependency.qualifier == Qualifier.Out
                 || dependency.qualifier == Qualifier.InOut)
-            .map(dependency => dependency.kind);
+            .map(dependency => ({ kind: dependency.kind, name: dependency.name }));
     }
 }

--- a/src/shader.ts
+++ b/src/shader.ts
@@ -1,5 +1,7 @@
 import Variable from './variable';
 import Function from './function';
+import Qualifier from './qualifier';
+import Type from './type';
 
 export default class Shader {
     public main: Function;
@@ -16,5 +18,20 @@ export default class Shader {
         return [...this.main.dependencies()]
             .map(dependency => dependency.declaration())
             .join('\n');
+    }
+
+    public inputs(): Type[] {
+        return [...this.main.dependencies()]
+            .filter(dependency => dependency.qualifier == Qualifier.In
+                || dependency.qualifier == Qualifier.InOut
+                || dependency.qualifier == Qualifier.Attribute)
+            .map(dependency => dependency.kind);
+    }
+
+    public outputs(): Type[] {
+        return [...this.main.dependencies()]
+            .filter(dependency => dependency.qualifier == Qualifier.Out
+                || dependency.qualifier == Qualifier.InOut)
+            .map(dependency => dependency.kind);
     }
 }

--- a/src/shaderpipeline.ts
+++ b/src/shaderpipeline.ts
@@ -1,0 +1,11 @@
+import Shader from './shader';
+
+export default class ShaderPipeline {
+    public readonly vertexSource: string;
+    public readonly fragmentSource: string;
+
+    constructor(vertexShader: Shader, fragmentShader: Shader) {
+        this.vertexSource = vertexShader.source();    
+        this.fragmentSource = fragmentShader.source();    
+    }
+}

--- a/src/shaderpipelinebuilder.ts
+++ b/src/shaderpipelinebuilder.ts
@@ -20,17 +20,30 @@ export default class ShaderPipelineBuilder {
             this.isWellFormed = false;
         }
 
-        const inTypes = this.fragmentShader.inputs().sort();
-        const outTypes = this.vertexShader.outputs().sort();
+        // Sort the inputs and outputs to ensure we can efficiently do a subset comparison. Equality doesn't
+        // work because we want to compare fields, so Set.has() doesn't work.
+        const compareVars = (a: { kind: Type, name: string }, b: { kind: Type, name: string }) => {
+            if (a.kind < b.kind) {
+                return -1;
+            } else if (b.kind < b.kind) {
+                return 1;
+            } else {
+                if (a.kind < b.kind) return -1;
+                else if (b.kind < a.kind) return 1;
+                else return 0;
+            }
+        };
+        const inVars = this.fragmentShader.inputs().sort(compareVars);
+        const outVars = this.vertexShader.outputs().sort(compareVars);
 
         let inIdx = 0;
-        for (let outIdx = 0; outIdx < outTypes.length && inIdx < inTypes.length; outIdx++) {
-            if (inTypes[inIdx] == outTypes[outIdx]) {
+        for (let outIdx = 0; outIdx < outVars.length && inIdx < inVars.length; outIdx++) {
+            if (inVars[inIdx].kind == outVars[outIdx].kind && inVars[inIdx].name == outVars[outIdx].name) {
                 inIdx++;
             }
         }
 
-        if (inIdx < inTypes.length) {
+        if (inIdx < inVars.length) {
             this.isWellFormed = false;
         }
     }

--- a/src/shaderpipelinebuilder.ts
+++ b/src/shaderpipelinebuilder.ts
@@ -1,0 +1,41 @@
+import Shader from './shader';
+import Type from './type';
+import ShaderPipeline from './shaderpipeline';
+
+export default class ShaderPipelineBuilder {
+    public isWellFormed: boolean;
+    private readonly vertexShader: Shader;
+    private readonly fragmentShader: Shader;
+
+    constructor(vertexShader: Shader, fragmentShader: Shader) {
+        this.vertexShader = vertexShader;
+        this.fragmentShader = fragmentShader;
+
+        // TODO: replace with throwing an exception
+
+        // Vertex shader outputs must be a superset of fragment shader inputs.
+        // Might want to enforce equality (need to check the standard), but for now, this should be sufficient.
+        this.isWellFormed = true;
+        if (this.vertexShader.outputs().length < this.fragmentShader.inputs().length) {
+            this.isWellFormed = false;
+        }
+
+        const inTypes = this.fragmentShader.inputs().sort();
+        const outTypes = this.vertexShader.outputs().sort();
+
+        let inIdx = 0;
+        for (let outIdx = 0; outIdx < outTypes.length && inIdx < inTypes.length; outIdx++) {
+            if (inTypes[inIdx] == outTypes[outIdx]) {
+                inIdx++;
+            }
+        }
+
+        if (inIdx < inTypes.length) {
+            this.isWellFormed = false;
+        }
+    }
+
+    public build(): ShaderPipeline {
+        return new ShaderPipeline(this.vertexShader, this.fragmentShader);
+    }
+}

--- a/test/shaderpipelinebuilder.spec.js
+++ b/test/shaderpipelinebuilder.spec.js
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import * as cgl from '../src/calder';
+
+describe('ShaderPipelineBuilder', () => {
+    describe('checkInputsAndOutputs', () => {
+        it('has all fragment shader outputs in vertex shader inputs', () => {
+            const ptColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'colour');            
+            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');            
+            const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
+            const colour = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'colour');
+            const outColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'outColour');
+
+            const vertexShader = new cgl.Shader(
+                new cgl.Function('main', [
+                    new cgl.Statement(
+                        new cgl.Assignment(
+                            new cgl.Reference(glPosition),
+                            new cgl.Reference(vertexPosition)
+                        )
+                    ),
+                    new cgl.Statement(
+                        new cgl.Assignment(
+                            new cgl.Reference(ptColour),
+                            new cgl.Reference(vertexPosition)
+                        )
+                    )
+                ])
+            );
+
+            const fragShader = new cgl.Shader(
+                new cgl.Function('main', [
+                    new cgl.Statement(
+                        new cgl.Assignment(
+                            new cgl.Reference(outColour),
+                            new cgl.Reference(colour)
+                        )
+                    )
+                ])
+            );
+
+            const pipelineBuilder = new cgl.ShaderPipelineBuilder(vertexShader, fragShader);
+
+            expect(pipelineBuilder.isWellFormed).to.be.true;
+        });
+
+        it('has some fragment shader outputs not in vertex shader inputs', () => {
+            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');            
+            const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
+            const depth = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Float, 'depth');
+            const outDepth = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Float, 'outDepth');
+
+            const vertexShader = new cgl.Shader(
+                new cgl.Function('main', [
+                    new cgl.Statement(
+                        new cgl.Assignment(
+                            new cgl.Reference(glPosition),
+                            new cgl.Reference(vertexPosition)
+                        )
+                    )
+                ])
+            );
+
+            const fragShader = new cgl.Shader(
+                new cgl.Function('main', [
+                    new cgl.Statement(
+                        new cgl.Assignment(
+                            new cgl.Reference(outDepth),
+                            new cgl.Reference(depth)
+                        )
+                    )
+                ])
+            );
+
+            const pipelineBuilder = new cgl.ShaderPipelineBuilder(vertexShader, fragShader);
+
+            expect(pipelineBuilder.isWellFormed).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
Builder has simple input/output checking from vertex to fragment shader. It only checks types; the eventual goal is to implement the complete [GLSL interface matching spec](https://www.khronos.org/opengl/wiki/Shader_Compilation#Interface_matching), which is recorded under #19.