### PR TITLE
Add custom set class

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "watch": "gulp watch",
     "build": "gulp",
     "start": "node build/js/index.js",
-    "test": "gulp && ./node_modules/.bin/mocha ./build/js/test/**/*.spec.js"
+    "test": "gulp && ./node_modules/.bin/mocha ./build/js/test/ --recursive"
   }
 }

--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -2,6 +2,7 @@ import Expression from './expression';
 import Variable from './variable';
 import Type from './type';
 import Reference from './reference';
+import Set from './util/set';
 
 export default class Assignment implements Expression {
     private lhs: Reference;
@@ -14,7 +15,7 @@ export default class Assignment implements Expression {
     }
 
     public dependencies(): Set<Variable> {
-        return new Set([...this.rhs.dependencies(), ...this.lhs.dependencies()]);
+        return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 
     public source(): string {

--- a/src/block.ts
+++ b/src/block.ts
@@ -2,6 +2,7 @@ import Variable from './variable';
 import Expression from './expression';
 import Statement from './statement';
 import Type from './type';
+import Set from './util/set';
 
 export default class Block implements Expression {
     private statements: Statement[];
@@ -21,9 +22,9 @@ export default class Block implements Expression {
 
     public dependencies(): Set<Variable> {
         return this.statements.reduce((union, statement) => (
-                new Set([...union, ...statement.dependencies()])
+                union.addAll(statement.dependencies())
             ),
-            new Set()
+            new Set<Variable>()
         );
     }
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,6 +1,7 @@
 import Variable from './variable';
 import SyntaxNode from './syntaxnode';
 import Statement from './statement';
+import Set from './util/set';
 
 export default class Function implements SyntaxNode {
     public readonly name: string;
@@ -13,9 +14,9 @@ export default class Function implements SyntaxNode {
 
     public dependencies(): Set<Variable> {
         return this.statements.reduce((union, statement) => (
-                new Set([...union, ...statement.dependencies()])
+                union.addAll(statement.dependencies())
             ),
-            new Set()
+            new Set<Variable>()
         );
     }
 

--- a/src/if.ts
+++ b/src/if.ts
@@ -2,6 +2,7 @@ import Variable from './variable';
 import Expression from './expression';
 import Block from './block';
 import Type from './type';
+import Set from './util/set';
 
 export default class If implements Expression {
     private condition: Expression;
@@ -19,11 +20,9 @@ export default class If implements Expression {
     }
 
     public dependencies(): Set<Variable> {
-        return new Set([
-            ...this.condition.dependencies(),
-            ...this.thenBlock.dependencies(),
-            ...this.elseBlock.dependencies()
-        ]);
+        return this.condition.dependencies()
+            .union(this.thenBlock.dependencies())
+            .union(this.elseBlock.dependencies());
     }
 
     public source(): string {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,6 +1,7 @@
 import Variable from './variable';
 import Type from './type';
 import Expression from './expression';
+import Set from './util/set';
 
 export default class Reference implements Expression {
     private variable: Variable;

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1,5 +1,6 @@
 import SyntaxNode from './syntaxnode';
 import Variable from './variable';
+import Set from './util/set';
 
 export default class Statement implements SyntaxNode {
     private node: SyntaxNode;

--- a/src/syntaxnode.ts
+++ b/src/syntaxnode.ts
@@ -1,4 +1,5 @@
 import Variable from './variable';
+import Set from './util/set';
 
 export default interface SyntaxNode {
     dependencies(): Set<Variable>;

--- a/src/util/hashable.ts
+++ b/src/util/hashable.ts
@@ -1,0 +1,3 @@
+export default interface Hashable {
+    hashCode(): string;
+}

--- a/src/util/set.ts
+++ b/src/util/set.ts
@@ -1,0 +1,93 @@
+import Hashable from './hashable';
+
+export default class Set<T extends Hashable> implements Iterable<T> {
+    private map: Map<string, T>;
+    public length: number;
+
+    constructor(iterable: Iterable<T> = []) {
+        this.map = new Map<string, T>();
+        this.length = 0;
+
+        this.addAll(iterable);
+    }
+
+    public [Symbol.iterator](): Iterator<T> {
+        return this.values();
+    }
+
+    public add(item: T): Set<T> {
+        this.map.set(item.hashCode(), item);
+        this.length = this.map.size;
+        return this;
+    }
+
+    public addAll(items: Iterable<T>): Set<T> {
+        for (let i of items) {
+            this.add(i);
+        }
+        return this;
+    }
+
+    public delete(item: T): Set<T> {
+        this.map.delete(item.hashCode());
+        this.length = this.map.size;
+        return this;
+    }
+
+    public deleteAll(items: Iterable<T>): Set<T> {
+        for (let item of items) {
+            this.delete(item);
+        }
+        return this;
+    }
+
+    public has(item: T): boolean {
+        return this.map.has(item.hashCode());
+    }
+
+    public values(): Iterator<T> {
+        return this.map.values();
+    }
+
+    public keys(): Iterator<string> {
+        return this.map.keys();
+    }
+
+    public entries(): IterableIterator<[string, T]> {
+        return this.map.entries();
+    }
+
+    public isSuperset(subset: Set<T>): boolean {
+        for (let elem of subset) {
+            if (!this.has(elem)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public isSubset(superset: Set<T>): boolean {
+        for (let elem of this) {
+            if (!superset.has(elem)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public isStrictSuperset(subset: Set<T>): boolean {
+        return this.isSuperset(subset) && this.length > subset.length;
+    }
+
+    public isStrictSubset(superset: Set<T>): boolean {
+        return this.isSubset(superset) && this.length < superset.length;
+    }
+
+    public union(other: Set<T>): Set<T> {
+        return new Set(this).addAll(other);
+    }
+
+    public intersection(other: Set<T>): Set<T> {
+        return new Set([...this].filter(i => other.has(i)));
+    }
+}

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,7 +1,8 @@
 import Qualifier from './qualifier';
 import Type from './type';
+import Hashable from './util/hashable';
 
-export default class Variable {
+export default class Variable implements Hashable {
     public readonly name: string;
     public readonly qualifier: Qualifier;
     public readonly kind: Type;
@@ -15,5 +16,9 @@ export default class Variable {
 
     public declaration(): string {
         return `${this.qualifier} ${this.kind} ${this.name};`;
+    }
+
+    public hashCode(): string {
+        return this.declaration();
     }
 }

--- a/src/while.ts
+++ b/src/while.ts
@@ -2,6 +2,7 @@ import Variable from './variable';
 import Expression from './expression';
 import Block from './block';
 import Type from './type';
+import Set from './util/set';
 
 export default class While implements Expression {
     protected condition: Expression;
@@ -17,10 +18,7 @@ export default class While implements Expression {
     }
 
     public dependencies(): Set<Variable> {
-        return new Set([
-            ...this.condition.dependencies(),
-            ...this.loopBlock.dependencies(),
-        ]);
+        return this.condition.dependencies().union(this.loopBlock.dependencies());
     }
 
     public source(): string {

--- a/test/util/set.spec.js
+++ b/test/util/set.spec.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import Set from '../../src/util/set';
+import Hashable from '../../src/util/hashable';
+
+// Make String implement Hashable
+String.prototype.hashCode = function() {
+    return this;
+};
+
+describe('Set', () => {
+    describe('add', () => {
+        it('adds to a set', () => {
+            const s = new Set(['a']);
+            s.add('b');
+            expect(s.has('a')).to.be.true;
+            expect(s.has('b')).to.be.true;
+        });
+    });
+    describe('addAll', () => {
+        it('adds multiple to a set', () => {
+            const s = new Set(['a']).addAll(['b', 'c']);
+            expect(s.has('a')).to.be.true;
+            expect(s.has('b')).to.be.true;
+            expect(s.has('c')).to.be.true;
+        });
+    });
+    describe('delete', () => {
+        it('removed from a set', () => {
+            expect(new Set(['a']).delete('a').has('a')).to.be.false;
+        });
+    });
+    describe('deleteAll', () => {
+        it('removes multiple to a set', () => {
+            const s = new Set(['a', 'b', 'c']).deleteAll(['b', 'c']);
+            expect(s.has('a')).to.be.true;
+            expect(s.has('b')).to.be.false;
+            expect(s.has('c')).to.be.false;
+        });
+    });
+    describe('isSuperset', () => {
+        it('works for a superset', () => {
+            expect(new Set(['a', 'b']).isSuperset(new Set(['a']))).to.be.true;
+        });
+        it('works for an equal set', () => {
+            expect(new Set(['a']).isSuperset(new Set(['a']))).to.be.true;
+        });
+        it('does not work for a subset', () => {
+            expect(new Set([]).isSuperset(new Set(['a']))).to.be.false;
+        });
+    });
+    describe('isSubset', () => {
+        it('works for a subset', () => {
+            expect(new Set(['a']).isSubset(new Set(['a', 'b']))).to.be.true;
+        });
+        it('works for an equal set', () => {
+            expect(new Set(['a']).isSubset(new Set(['a']))).to.be.true;
+        });
+        it('does not work for a superset', () => {
+            expect(new Set(['a', 'b']).isSubset(new Set(['a']))).to.be.false;
+        });
+    });
+    describe('isStrictSuperset', () => {
+        it('works for a superset', () => {
+            expect(new Set(['a', 'b']).isStrictSuperset(new Set(['a']))).to.be.true;
+        });
+        it('does not work for an equal set', () => {
+            expect(new Set(['a']).isStrictSuperset(new Set(['a']))).to.be.false;
+        });
+        it('does not work for a subset', () => {
+            expect(new Set([]).isStrictSuperset(new Set(['a']))).to.be.false;
+        });
+    });
+    describe('isStrictSubset', () => {
+        it('works for a subset', () => {
+            expect(new Set(['a']).isStrictSubset(new Set(['a', 'b']))).to.be.true;
+        });
+        it('does not work for an equal set', () => {
+            expect(new Set(['a']).isStrictSubset(new Set(['a']))).to.be.false;
+        });
+        it('does not work for a superset', () => {
+            expect(new Set(['a', 'b']).isStrictSubset(new Set(['a']))).to.be.false;
+        });
+    });
+    describe('union', () => {
+        it('combines the terms from both', () => {
+            const s = new Set(['a', 'b']).union(new Set(['c', 'd']));
+            expect(s.has('a')).to.be.true;
+            expect(s.has('b')).to.be.true;
+            expect(s.has('c')).to.be.true;
+            expect(s.has('d')).to.be.true;
+        });
+    });
+    describe('intersection', () => {
+        it('keeps only common terms', () => {
+            const s = new Set(['a', 'b']).intersection(new Set(['b', 'c']));
+            expect(s.has('b')).to.be.true;
+            expect(s.length).to.equal(1);
+        });
+    });
+});


### PR DESCRIPTION
- Override `hashCode(): string` to have custom object equality for the sake of the set `has(): bool` method
- Has union, intersection
- All methods are chainable!
- Changes the test script to run all tests always. I think the default behaviour is to only run test files that change, but when I change source files, I want to rerun existing tests too.