### PR TITLE
Adds support for basic structs

### DIFF
--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -1,5 +1,5 @@
 import Expression from './expression';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Reference from './reference';
 import Set from './util/set';
 import Type from './type';
@@ -14,7 +14,7 @@ export default class Assignment implements Expression {
         this.rhs = rhs;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 

--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -1,8 +1,8 @@
 import Expression from './expression';
-import Variable from './variable';
-import Type from './type';
+import Interface from './interface';
 import Reference from './reference';
 import Set from './util/set';
+import Type from './type';
 
 export default class Assignment implements Expression {
     private lhs: Reference;
@@ -14,7 +14,7 @@ export default class Assignment implements Expression {
         this.rhs = rhs;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,8 +1,8 @@
-import Variable from './variable';
 import Expression from './expression';
+import Interface from './interface';
+import Set from './util/set';
 import Statement from './statement';
 import Type from './type';
-import Set from './util/set';
 
 export default class Block implements Expression {
     private statements: Statement[];
@@ -20,11 +20,11 @@ export default class Block implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.statements.reduce((union, statement) => (
                 union.addAll(statement.dependencies())
             ),
-            new Set<Variable>()
+            new Set<Interface>()
         );
     }
 

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,5 +1,5 @@
 import Expression from './expression';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import Statement from './statement';
 import Type from './type';
@@ -20,11 +20,11 @@ export default class Block implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.statements.reduce((union, statement) => (
                 union.addAll(statement.dependencies())
             ),
-            new Set<Interface>()
+            new Set<InterfaceVariable>()
         );
     }
 

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -33,7 +33,7 @@ export { default as Shader } from './shader';
 export { default as Qualifier } from './qualifier';
 export { default as Type } from './type';
 export { default as If } from './if'
-export { default as Interface } from './interface';
+export { default as InterfaceVariable } from './interface';
 export { default as Block } from './block'
 export { default as While } from './while'
 export { default as DoWhile } from './dowhile'

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -36,5 +36,6 @@ export { default as If } from './if'
 export { default as Block } from './block'
 export { default as While } from './while'
 export { default as DoWhile } from './dowhile'
+export { default as Struct } from './struct'
 export { default as ShaderPipelineBuilder } from './shaderpipelinebuilder';
 export { default as ShaderPipeline } from './shaderpipeline';

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -33,6 +33,7 @@ export { default as Shader } from './shader';
 export { default as Qualifier } from './qualifier';
 export { default as Type } from './type';
 export { default as If } from './if'
+export { default as Interface } from './interface';
 export { default as Block } from './block'
 export { default as While } from './while'
 export { default as DoWhile } from './dowhile'

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,4 +1,4 @@
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import Statement from './statement';
 import SyntaxNode from './syntaxnode';
@@ -12,11 +12,11 @@ export default class Function implements SyntaxNode {
         this.statements = statements;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.statements.reduce((union, statement) => (
                 union.addAll(statement.dependencies())
             ),
-            new Set<Interface>()
+            new Set<InterfaceVariable>()
         );
     }
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,7 +1,7 @@
-import Variable from './variable';
-import SyntaxNode from './syntaxnode';
-import Statement from './statement';
+import Interface from './interface';
 import Set from './util/set';
+import Statement from './statement';
+import SyntaxNode from './syntaxnode';
 
 export default class Function implements SyntaxNode {
     public readonly name: string;
@@ -12,11 +12,11 @@ export default class Function implements SyntaxNode {
         this.statements = statements;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.statements.reduce((union, statement) => (
                 union.addAll(statement.dependencies())
             ),
-            new Set<Variable>()
+            new Set<Interface>()
         );
     }
 

--- a/src/if.ts
+++ b/src/if.ts
@@ -1,6 +1,6 @@
 import Block from './block';
 import Expression from './expression';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';
 
@@ -19,7 +19,7 @@ export default class If implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.condition.dependencies()
             .union(this.thenBlock.dependencies())
             .union(this.elseBlock.dependencies());

--- a/src/if.ts
+++ b/src/if.ts
@@ -1,8 +1,8 @@
-import Variable from './variable';
-import Expression from './expression';
 import Block from './block';
-import Type from './type';
+import Expression from './expression';
+import Interface from './interface';
 import Set from './util/set';
+import Type from './type';
 
 export default class If implements Expression {
     private condition: Expression;
@@ -19,7 +19,7 @@ export default class If implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.condition.dependencies()
             .union(this.thenBlock.dependencies())
             .union(this.elseBlock.dependencies());

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -3,7 +3,7 @@ import Qualifier from './qualifier';
 import Type from './type';
 import Variable from './variable';
 
-export default class Interface implements Hashable {
+export default class InterfaceVariable implements Hashable {
     public readonly name: string;
     public readonly qualifier: Qualifier;
     public readonly kind: Type;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,27 @@
+import Hashable from './util/hashable';
+import Qualifier from './qualifier';
+import Type from './type';
+import Variable from './variable';
+
+export default class Interface implements Hashable {
+    public readonly name: string;
+    public readonly qualifier: Qualifier;
+    public readonly kind: Type;
+    private variable: Variable;
+
+    // TODO: typecheck kind
+    constructor(qualifier: Qualifier, variable: Variable) {
+        this.qualifier = qualifier;
+        this.name = variable.name;
+        this.kind = variable.kind;
+        this.variable = variable;
+    }
+
+    public declaration(): string {
+        return `${this.qualifier} ${this.variable.declaration()}`;
+    }
+
+    public hashCode(): string {
+        return this.declaration();
+    }
+}

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,16 +1,16 @@
-import Variable from './variable';
-import Type from './type';
 import Expression from './expression';
+import Interface from './interface';
 import Set from './util/set';
+import Type from './type';
 
 export default class Reference implements Expression {
-    private variable: Variable;
+    private variable: Interface;
 
-    constructor(variable: Variable) {
+    constructor(variable: Interface) {
         this.variable = variable;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return new Set([this.variable]);
     }
 

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,16 +1,16 @@
 import Expression from './expression';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';
 
 export default class Reference implements Expression {
-    private variable: Interface;
+    private variable: InterfaceVariable;
 
-    constructor(variable: Interface) {
+    constructor(variable: InterfaceVariable) {
         this.variable = variable;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return new Set([this.variable]);
     }
 

--- a/src/shader.ts
+++ b/src/shader.ts
@@ -1,5 +1,5 @@
 import Function from './function';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Qualifier from './qualifier';
 import Type from './type';
 

--- a/src/shader.ts
+++ b/src/shader.ts
@@ -1,5 +1,5 @@
-import Variable from './variable';
 import Function from './function';
+import Interface from './interface';
 import Qualifier from './qualifier';
 import Type from './type';
 
@@ -8,7 +8,7 @@ export default class Shader {
 
     constructor(main: Function = new Function('main')) {
         this.main = main;
-    } 
+    }
 
     public source(): string {
         return `${this.header()}\n${this.main.source()}`;

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1,6 +1,6 @@
-import SyntaxNode from './syntaxnode';
-import Variable from './variable';
+import Interface from './interface';
 import Set from './util/set';
+import SyntaxNode from './syntaxnode';
 
 export default class Statement implements SyntaxNode {
     private node: SyntaxNode;
@@ -9,7 +9,7 @@ export default class Statement implements SyntaxNode {
         this.node = node;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.node.dependencies();
     }
 

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1,4 +1,4 @@
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import SyntaxNode from './syntaxnode';
 
@@ -9,7 +9,7 @@ export default class Statement implements SyntaxNode {
         this.node = node;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.node.dependencies();
     }
 

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,0 +1,34 @@
+import Variable from './variable';
+
+/**
+ * struct type-name {
+ *   members
+ * } struct-name[]; // Optionally an array
+ */
+export default class Struct implements SyntaxNode {
+    public readonly name: string;
+    private members: Variable[];
+    private isArray: boolean;
+
+    constructor(name: string, members: Variable[], isArray: boolean = false) {
+        this.name = name;
+        this.members = members;
+        this.isArray = false;
+    }
+
+    public dependencies(): Set<Variable> {
+        return new Set(this.members);
+    }
+
+    public source(): string {
+        return `struct ${this.name}` +
+            this.members
+                .map(member => member.declaration())
+                .join('\n') +
+            `${this.name + this.arraySuffix()}};`;
+    }
+
+    private arraySuffix(): void {
+        (this.isArray) ? '[]' : '';
+    }
+}

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,3 +1,4 @@
+import SyntaxNode from './syntaxnode';
 import Variable from './variable';
 
 /**
@@ -13,7 +14,7 @@ export default class Struct implements SyntaxNode {
     constructor(name: string, members: Variable[], isArray: boolean = false) {
         this.name = name;
         this.members = members;
-        this.isArray = false;
+        this.isArray = isArray;
     }
 
     public dependencies(): Set<Variable> {
@@ -21,14 +22,14 @@ export default class Struct implements SyntaxNode {
     }
 
     public source(): string {
-        return `struct ${this.name}` +
+        return `struct ${this.name} {` +
             this.members
                 .map(member => member.declaration())
                 .join('\n') +
-            `${this.name + this.arraySuffix()}};`;
+            `} ${this.name + this.arraySuffix()};`;
     }
 
-    private arraySuffix(): void {
-        (this.isArray) ? '[]' : '';
+    private arraySuffix(): string {
+        return this.isArray ? '[]' : '';
     }
 }

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,4 +1,4 @@
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Qualifier from './qualifier';
 import Set from './util/set';
 import SyntaxNode from './syntaxnode';
@@ -7,7 +7,7 @@ import Variable from './variable';
 /**
  * struct type-name {
  *   members
- * } struct-name;
+ * };
  */
 export default class Struct implements SyntaxNode {
     public readonly name: string;
@@ -20,8 +20,8 @@ export default class Struct implements SyntaxNode {
         this.members = members;
     }
 
-    public dependencies(): Set<Interface> {
-        return new Set<Interface>();
+    public dependencies(): Set<InterfaceVariable> {
+        return new Set<InterfaceVariable>();
     }
 
     public source(): string {

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,4 +1,5 @@
 import Interface from './interface';
+import Qualifier from './qualifier';
 import Set from './util/set';
 import SyntaxNode from './syntaxnode';
 import Variable from './variable';
@@ -10,19 +11,21 @@ import Variable from './variable';
  */
 export default class Struct implements SyntaxNode {
     public readonly name: string;
+    public readonly qualifier: Qualifier;
     private members: Variable[];
 
-    constructor(name: string, members: Variable[]) {
+    constructor(qualifier: Qualifier, name: string, members: Variable[]) {
+        this.qualifier = qualifier
         this.name = name;
         this.members = members;
     }
 
     public dependencies(): Set<Interface> {
-        return new Set();
+        return new Set<Interface>();
     }
 
     public source(): string {
-        return `struct ${this.name} {` +
+        return `${this.qualifier} struct ${this.name} {` +
             this.members
                 .map(member => member.declaration())
                 .join('\n') +

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -29,6 +29,6 @@ export default class Struct implements SyntaxNode {
             this.members
                 .map(member => member.declaration())
                 .join('\n') +
-            `} ${this.name};`;
+            '};';
     }
 }

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,24 +1,24 @@
+import Interface from './interface';
+import Set from './util/set';
 import SyntaxNode from './syntaxnode';
 import Variable from './variable';
 
 /**
  * struct type-name {
  *   members
- * } struct-name[]; // Optionally an array
+ * } struct-name;
  */
 export default class Struct implements SyntaxNode {
     public readonly name: string;
     private members: Variable[];
-    private isArray: boolean;
 
-    constructor(name: string, members: Variable[], isArray: boolean = false) {
+    constructor(name: string, members: Variable[]) {
         this.name = name;
         this.members = members;
-        this.isArray = isArray;
     }
 
-    public dependencies(): Set<Variable> {
-        return new Set(this.members);
+    public dependencies(): Set<Interface> {
+        return new Set();
     }
 
     public source(): string {
@@ -26,10 +26,6 @@ export default class Struct implements SyntaxNode {
             this.members
                 .map(member => member.declaration())
                 .join('\n') +
-            `} ${this.name + this.arraySuffix()};`;
-    }
-
-    private arraySuffix(): string {
-        return this.isArray ? '[]' : '';
+            `} ${this.name};`;
     }
 }

--- a/src/syntaxnode.ts
+++ b/src/syntaxnode.ts
@@ -1,7 +1,7 @@
-import Variable from './variable';
+import Interface from './interface';
 import Set from './util/set';
 
 export default interface SyntaxNode {
-    dependencies(): Set<Variable>;
+    dependencies(): Set<Interface>;
     source(): string;
 }

--- a/src/syntaxnode.ts
+++ b/src/syntaxnode.ts
@@ -1,7 +1,7 @@
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 
 export default interface SyntaxNode {
-    dependencies(): Set<Interface>;
+    dependencies(): Set<InterfaceVariable>;
     source(): string;
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-// TODO: Deal with structs and arrays
+// TODO: Deal with arrays
 enum Type {
     Void = 'void',
     Bool = 'bool',
@@ -17,7 +17,8 @@ enum Type {
     Mat3 = 'mat3',
     Mat4 = 'mat4',
     Sampler2D = 'sampler2D',
-    SamplerCube = 'samplerCube'
+    SamplerCube = 'samplerCube',
+    Struct = 'struct'
 }
 
 export default Type;

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,24 +1,15 @@
-import Qualifier from './qualifier';
 import Type from './type';
-import Hashable from './util/hashable';
 
-export default class Variable implements Hashable {
+export default class Variable {
     public readonly name: string;
-    public readonly qualifier: Qualifier;
     public readonly kind: Type;
 
-    // TODO: typecheck kind
-    constructor(qualifier: Qualifier, kind: Type, name: string) {
+    constructor(kind: Type, name: string) {
         this.kind = kind;
-        this.qualifier = qualifier;
         this.name = name;
     }
 
     public declaration(): string {
-        return `${this.qualifier} ${this.kind} ${this.name};`;
-    }
-
-    public hashCode(): string {
-        return this.declaration();
+        return `${this.kind} ${this.name};`;
     }
 }

--- a/src/while.ts
+++ b/src/while.ts
@@ -1,6 +1,6 @@
 import Block from './block';
 import Expression from './expression';
-import Interface from './interface';
+import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';
 
@@ -17,7 +17,7 @@ export default class While implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Interface> {
+    public dependencies(): Set<InterfaceVariable> {
         return this.condition.dependencies().union(this.loopBlock.dependencies());
     }
 

--- a/src/while.ts
+++ b/src/while.ts
@@ -1,8 +1,8 @@
-import Variable from './variable';
-import Expression from './expression';
 import Block from './block';
-import Type from './type';
+import Expression from './expression';
+import Interface from './interface';
 import Set from './util/set';
+import Type from './type';
 
 export default class While implements Expression {
     protected condition: Expression;
@@ -17,7 +17,7 @@ export default class While implements Expression {
         return Type.Void;
     }
 
-    public dependencies(): Set<Variable> {
+    public dependencies(): Set<Interface> {
         return this.condition.dependencies().union(this.loopBlock.dependencies());
     }
 

--- a/test/assignment.spec.js
+++ b/test/assignment.spec.js
@@ -6,10 +6,10 @@ describe('Assignment', () => {
         it('references both the left and right hand sides', () => {
             const assignment = new cgl.Assignment(
                 new cgl.Reference(
-                    new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'lhs')
+                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs'))
                 ),
                 new cgl.Reference(
-                    new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'rhs')
+                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs'))
                 )
             );
 

--- a/test/assignment.spec.js
+++ b/test/assignment.spec.js
@@ -6,10 +6,10 @@ describe('Assignment', () => {
         it('references both the left and right hand sides', () => {
             const assignment = new cgl.Assignment(
                 new cgl.Reference(
-                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs'))
+                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs'))
                 ),
                 new cgl.Reference(
-                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs'))
+                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs'))
                 )
             );
 

--- a/test/block.spec.js
+++ b/test/block.spec.js
@@ -6,10 +6,10 @@ describe('Block', () => {
         it('references all included statements', () => {
             const block = new cgl.Block([
                 new cgl.Reference(
-                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
+                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                 ),
                 new cgl.Reference(
-                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
+                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                 )
             ]);
 
@@ -32,12 +32,12 @@ describe('Block', () => {
             const block = new cgl.Block([
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
+                        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                     )
                 ),
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
+                        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                     )
                 )
             ]);
@@ -57,12 +57,12 @@ describe('Block', () => {
             const block = new cgl.Block([
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
+                        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                     )
                 ),
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
+                        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                     )
                 )
             ]);

--- a/test/block.spec.js
+++ b/test/block.spec.js
@@ -6,10 +6,10 @@ describe('Block', () => {
         it('references all included statements', () => {
             const block = new cgl.Block([
                 new cgl.Reference(
-                    new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'a')
+                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                 ),
                 new cgl.Reference(
-                    new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'b')
+                    new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                 )
             ]);
 
@@ -32,12 +32,12 @@ describe('Block', () => {
             const block = new cgl.Block([
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'a')
+                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                     )
                 ),
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'b')
+                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                     )
                 )
             ]);
@@ -57,12 +57,12 @@ describe('Block', () => {
             const block = new cgl.Block([
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'a')
+                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'a'))
                     )
                 ),
                 new cgl.Statement(
                     new cgl.Reference(
-                        new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'b')
+                        new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'b'))
                     )
                 )
             ]);

--- a/test/dowhile.spec.js
+++ b/test/dowhile.spec.js
@@ -37,5 +37,5 @@ describe('DoWhile', () => {
 
             expect(doWhileStmt.source()).to.equalIgnoreSpaces('do { a=b; } while (a)');
         });
-    })
+    });
 });

--- a/test/dowhile.spec.js
+++ b/test/dowhile.spec.js
@@ -4,13 +4,13 @@ import * as cgl from '../src/calder';
 describe('DoWhile', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
-            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
+            const conditionInterfaceVariable = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterfaceVariable1 = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterfaceVariable1'));
             const doWhileStmt = new cgl.DoWhile(
-                new cgl.Reference(conditionInterface),
+                new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -18,14 +18,14 @@ describe('DoWhile', () => {
             const dependencyNames = [...doWhileStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterfaceVariable1']);
         });
     });
 
     describe('source', () => {
         it('is well formed', () => {
-            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
+            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const doWhileStmt = new cgl.DoWhile(
                 new cgl.Reference(a),
                 new cgl.Block([

--- a/test/dowhile.spec.js
+++ b/test/dowhile.spec.js
@@ -4,13 +4,13 @@ import * as cgl from '../src/calder';
 describe('DoWhile', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionVariable = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'condition');
-            const someVariable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'someVariable1');
+            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
             const doWhileStmt = new cgl.DoWhile(
-                new cgl.Reference(conditionVariable),
+                new cgl.Reference(conditionInterface),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionVariable), new cgl.Reference(someVariable1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
                     )
                 ])
             );
@@ -18,14 +18,14 @@ describe('DoWhile', () => {
             const dependencyNames = [...doWhileStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someVariable1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
         });
     });
 
     describe('source', () => {
         it('is well formed', () => {
-            const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
-            const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const doWhileStmt = new cgl.DoWhile(
                 new cgl.Reference(a),
                 new cgl.Block([

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import * as cgl from '../src/calder';
 
 function basicMain() {
-    const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
-    const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
+    const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+    const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
     const main = new cgl.Function('main', [
         new cgl.Assignment(
             new cgl.Reference(glPosition),

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import * as cgl from '../src/calder';
 
 function basicMain() {
-    const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');
-    const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
+    const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+    const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
     const main = new cgl.Function('main', [
         new cgl.Assignment(
             new cgl.Reference(glPosition),

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -4,19 +4,19 @@ import * as cgl from '../src/calder';
 describe('If', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
-            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
-            const someInterface2 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface2'));
+            const conditionInterfaceVariable = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterfaceVariable1 = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterfaceVariable1'));
+            const someInterfaceVariable2 = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterfaceVariable2'));
             const ifStmt = new cgl.If(
-                new cgl.Reference(conditionInterface),
+                new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ]),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface2))
+                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable2))
                     )
                 ])
             );
@@ -24,17 +24,17 @@ describe('If', () => {
             const dependencyNames = [...ifStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someInterface1', 'someInterface2']);
+            expect(dependencyNames).to.eql(['condition', 'someInterfaceVariable1', 'someInterfaceVariable2']);
         });
 
         it('excludes the else block if none is present', () => {
-            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
-            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
+            const conditionInterfaceVariable = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterfaceVariable1 = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterfaceVariable1'));
             const ifStmt = new cgl.If(
-                new cgl.Reference(conditionInterface),
+                new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -42,14 +42,14 @@ describe('If', () => {
             const dependencyNames = [...ifStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterfaceVariable1']);
         });
     });
 
     describe('source', () => {
         it('has no else block if none is provided', () => {
-            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
+            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([
@@ -65,8 +65,8 @@ describe('If', () => {
 
     describe('source', () => {
         it('has no else block if an empty block is provided', () => {
-            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
+            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -4,19 +4,19 @@ import * as cgl from '../src/calder';
 describe('If', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionVariable = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'condition');
-            const someVariable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'someVariable1');
-            const someVariable2 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'someVariable2');
+            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
+            const someInterface2 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface2'));
             const ifStmt = new cgl.If(
-                new cgl.Reference(conditionVariable),
+                new cgl.Reference(conditionInterface),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionVariable), new cgl.Reference(someVariable1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
                     )
                 ]),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionVariable), new cgl.Reference(someVariable2))
+                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface2))
                     )
                 ])
             );
@@ -24,17 +24,17 @@ describe('If', () => {
             const dependencyNames = [...ifStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someVariable1', 'someVariable2']);
+            expect(dependencyNames).to.eql(['condition', 'someInterface1', 'someInterface2']);
         });
 
         it('excludes the else block if none is present', () => {
-            const conditionVariable = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'condition');
-            const someVariable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'someVariable1');
+            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
             const ifStmt = new cgl.If(
-                new cgl.Reference(conditionVariable),
+                new cgl.Reference(conditionInterface),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionVariable), new cgl.Reference(someVariable1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
                     )
                 ])
             );
@@ -42,14 +42,14 @@ describe('If', () => {
             const dependencyNames = [...ifStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someVariable1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
         });
     });
 
     describe('source', () => {
         it('has no else block if none is provided', () => {
-            const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
-            const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([
@@ -61,12 +61,12 @@ describe('If', () => {
 
             expect(ifStmt.source()).to.equalIgnoreSpaces('if (a) { a=b; }');
         });
-    })
+    });
 
     describe('source', () => {
         it('has no else block if an empty block is provided', () => {
-            const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
-            const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([
@@ -79,5 +79,5 @@ describe('If', () => {
 
             expect(ifStmt.source()).to.equalIgnoreSpaces('if (a) { a=b; }');
         });
-    })
+    });
 });

--- a/test/reference.spec.js
+++ b/test/reference.spec.js
@@ -5,7 +5,7 @@ describe('Reference', () => {
     describe('dependencies', () => {
         it('references the contained variable', () => {
             const ref = new cgl.Reference(
-                new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'test')
+                new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'test'))
             );
 
             expect(

--- a/test/reference.spec.js
+++ b/test/reference.spec.js
@@ -5,7 +5,7 @@ describe('Reference', () => {
     describe('dependencies', () => {
         it('references the contained variable', () => {
             const ref = new cgl.Reference(
-                new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'test'))
+                new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'test'))
             );
 
             expect(

--- a/test/shader.spec.js
+++ b/test/shader.spec.js
@@ -6,8 +6,8 @@ chai.use(chaiString);
 const { expect } = chai;
 
 function basicShader() {
-    const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable('vec4', 'gl_Position'));
-    const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable('vec4', 'vertexPosition'));
+    const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable('vec4', 'gl_Position'));
+    const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.Variable('vec4', 'vertexPosition'));
     const shader = new cgl.Shader(
         new cgl.Function('main', [
             new cgl.Statement(

--- a/test/shader.spec.js
+++ b/test/shader.spec.js
@@ -6,8 +6,8 @@ chai.use(chaiString);
 const { expect } = chai;
 
 function basicShader() {
-    const glPosition = new cgl.Variable(cgl.Qualifier.Out, 'vec4', 'gl_Position');
-    const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, 'vec4', 'vertexPosition');
+    const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable('vec4', 'gl_Position'));
+    const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable('vec4', 'vertexPosition'));
     const shader = new cgl.Shader(
         new cgl.Function('main', [
             new cgl.Statement(

--- a/test/shaderpipelinebuilder.spec.js
+++ b/test/shaderpipelinebuilder.spec.js
@@ -4,11 +4,11 @@ import * as cgl from '../src/calder';
 describe('ShaderPipelineBuilder', () => {
     describe('checkInputsAndOutputs', () => {
         it('has all fragment shader outputs in vertex shader inputs', () => {
-            const ptColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'colour');
-            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');
-            const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
-            const colour = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'colour');
-            const outColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'outColour');
+            const ptColour = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'colour'));
+            const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+            const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
+            const colour = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'colour'));
+            const outColour = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'outColour'));
 
             const vertexShader = new cgl.Shader(
                 new cgl.Function('main', [
@@ -44,10 +44,10 @@ describe('ShaderPipelineBuilder', () => {
         });
 
         it('has some fragment shader outputs not in vertex shader inputs', () => {
-            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');
-            const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
-            const depth = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Float, 'depth');
-            const outDepth = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Float, 'outDepth');
+            const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+            const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
+            const depth = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Float, 'depth'));
+            const outDepth = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Float, 'outDepth'));
 
             const vertexShader = new cgl.Shader(
                 new cgl.Function('main', [

--- a/test/shaderpipelinebuilder.spec.js
+++ b/test/shaderpipelinebuilder.spec.js
@@ -4,11 +4,11 @@ import * as cgl from '../src/calder';
 describe('ShaderPipelineBuilder', () => {
     describe('checkInputsAndOutputs', () => {
         it('has all fragment shader outputs in vertex shader inputs', () => {
-            const ptColour = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'colour'));
-            const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
-            const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
-            const colour = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'colour'));
-            const outColour = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'outColour'));
+            const ptColour = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'colour'));
+            const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+            const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
+            const colour = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'colour'));
+            const outColour = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'outColour'));
 
             const vertexShader = new cgl.Shader(
                 new cgl.Function('main', [
@@ -44,10 +44,10 @@ describe('ShaderPipelineBuilder', () => {
         });
 
         it('has some fragment shader outputs not in vertex shader inputs', () => {
-            const glPosition = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
-            const vertexPosition = new cgl.Interface(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
-            const depth = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Float, 'depth'));
-            const outDepth = new cgl.Interface(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Float, 'outDepth'));
+            const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Vec4, 'gl_Position'));
+            const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.Variable(cgl.Type.Vec4, 'vertexPosition'));
+            const depth = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Float, 'depth'));
+            const outDepth = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.Variable(cgl.Type.Float, 'outDepth'));
 
             const vertexShader = new cgl.Shader(
                 new cgl.Function('main', [

--- a/test/shaderpipelinebuilder.spec.js
+++ b/test/shaderpipelinebuilder.spec.js
@@ -4,8 +4,8 @@ import * as cgl from '../src/calder';
 describe('ShaderPipelineBuilder', () => {
     describe('checkInputsAndOutputs', () => {
         it('has all fragment shader outputs in vertex shader inputs', () => {
-            const ptColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'colour');            
-            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');            
+            const ptColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'colour');
+            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');
             const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
             const colour = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Vec4, 'colour');
             const outColour = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'outColour');
@@ -44,7 +44,7 @@ describe('ShaderPipelineBuilder', () => {
         });
 
         it('has some fragment shader outputs not in vertex shader inputs', () => {
-            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');            
+            const glPosition = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Vec4, 'gl_Position');
             const vertexPosition = new cgl.Variable(cgl.Qualifier.Attribute, cgl.Type.Vec4, 'vertexPosition');
             const depth = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Float, 'depth');
             const outDepth = new cgl.Variable(cgl.Qualifier.Out, cgl.Type.Float, 'outDepth');

--- a/test/struct.spec.js
+++ b/test/struct.spec.js
@@ -2,47 +2,19 @@ import { expect } from 'chai';
 import * as cgl from '../src/calder';
 
 describe('Struct', () => {
-    describe('dependencies', () => {
-        it('includes all variable declarations', () => {
-            const variable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'variable1');
-            const variable2 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'variable2');
-            const structure = new cgl.Struct('structName', [variable1, variable2]);
-
-            const dependencyNames = [...structure.dependencies()]
-                  .map(dependency => dependency.name)
-                  .sort();
-            expect(dependencyNames).to.eql(['variable1', 'variable2']);
-        });
-    });
-
     describe('source', () => {
-        const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
-        const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+        const a = new cgl.Variable(cgl.Type.Bool, 'a');
+        const b = new cgl.Variable(cgl.Type.Bool, 'b');
 
-        describe('regular struct', () => {
-            it('is well formed', () => {
-                const structure = new cgl.Struct('structName', [a, b]);
+        it('is well formed', () => {
+            const structure = new cgl.Struct('structName', [a, b]);
 
-                expect(structure.source()).to.equalIgnoreSpaces(
-                    `struct structName {
-                      in bool a;
-                      in bool b;
-                    } structName;`
-                );
-            });
-        });
-
-        describe('array struct', () => {
-            it('is well formed', () => {
-                const structure = new cgl.Struct('structName', [a, b], true);
-
-                expect(structure.source()).to.equalIgnoreSpaces(
-                    `struct structName {
-                      in bool a;
-                      in bool b;
-                    } structName[];`
-                );
-            });
+            expect(structure.source()).to.equalIgnoreSpaces(
+                `struct structName {
+                    bool a;
+                    bool b;
+                } structName;`
+            );
         });
     });
 });

--- a/test/struct.spec.js
+++ b/test/struct.spec.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import * as cgl from '../src/calder';
+
+describe('Struct', () => {
+    describe('dependencies', () => {
+        it('includes all variable declarations', () => {
+            const variable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'variable1');
+            const variable2 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'variable2');
+            const structure = new cgl.Struct('structName', [variable1, variable2]);
+
+            const dependencyNames = [...structure.dependencies()]
+                  .map(dependency => dependency.name)
+                  .sort();
+            expect(dependencyNames).to.eql(['variable1', 'variable2']);
+        });
+    });
+
+    describe('source', () => {
+        const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
+        const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+
+        describe('regular struct', () => {
+            it('is well formed', () => {
+                const structure = new cgl.Struct('structName', [a, b]);
+
+                expect(structure.source()).to.equalIgnoreSpaces(
+                    `struct structName {
+                      in bool a;
+                      in bool b;
+                    } structName;`
+                );
+            });
+        });
+
+        describe('array struct', () => {
+            it('is well formed', () => {
+                const structure = new cgl.Struct('structName', [a, b], true);
+
+                expect(structure.source()).to.equalIgnoreSpaces(
+                    `struct structName {
+                      in bool a;
+                      in bool b;
+                    } structName[];`
+                );
+            });
+        });
+    });
+});

--- a/test/struct.spec.js
+++ b/test/struct.spec.js
@@ -13,7 +13,7 @@ describe('Struct', () => {
                 `const struct structName {
                     bool a;
                     bool b;
-                } structName;`
+                };`
             );
         });
     });

--- a/test/struct.spec.js
+++ b/test/struct.spec.js
@@ -7,10 +7,10 @@ describe('Struct', () => {
         const b = new cgl.Variable(cgl.Type.Bool, 'b');
 
         it('is well formed', () => {
-            const structure = new cgl.Struct('structName', [a, b]);
+            const structure = new cgl.Struct(cgl.Qualifier.Const, 'structName', [a, b]);
 
             expect(structure.source()).to.equalIgnoreSpaces(
-                `struct structName {
+                `const struct structName {
                     bool a;
                     bool b;
                 } structName;`

--- a/test/while.spec.js
+++ b/test/while.spec.js
@@ -37,5 +37,5 @@ describe('While', () => {
 
             expect(whileStmt.source()).to.equalIgnoreSpaces('while (a) { a=b; }');
         });
-    })
+    });
 });

--- a/test/while.spec.js
+++ b/test/while.spec.js
@@ -4,13 +4,13 @@ import * as cgl from '../src/calder';
 describe('While', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionVariable = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'condition');
-            const someVariable1 = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'someVariable1');
+            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
             const whileStmt = new cgl.While(
-                new cgl.Reference(conditionVariable),
+                new cgl.Reference(conditionInterface),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionVariable), new cgl.Reference(someVariable1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
                     )
                 ])
             );
@@ -18,14 +18,14 @@ describe('While', () => {
             const dependencyNames = [...whileStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someVariable1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
         });
     });
 
     describe('source', () => {
         it('is well formed', () => {
-            const a = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'a');
-            const b = new cgl.Variable(cgl.Qualifier.In, cgl.Type.Bool, 'b');
+            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const whileStmt = new cgl.While(
                 new cgl.Reference(a),
                 new cgl.Block([

--- a/test/while.spec.js
+++ b/test/while.spec.js
@@ -4,13 +4,13 @@ import * as cgl from '../src/calder';
 describe('While', () => {
     describe('dependencies', () => {
         it('includes both the then and else blocks', () => {
-            const conditionInterface = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
-            const someInterface1 = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterface1'));
+            const conditionInterfaceVariable = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'condition'));
+            const someInterfaceVariable1 = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'someInterfaceVariable1'));
             const whileStmt = new cgl.While(
-                new cgl.Reference(conditionInterface),
+                new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterface), new cgl.Reference(someInterface1))
+                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -18,14 +18,14 @@ describe('While', () => {
             const dependencyNames = [...whileStmt.dependencies()]
                 .map(dependency => dependency.name)
                 .sort();
-            expect(dependencyNames).to.eql(['condition', 'someInterface1']);
+            expect(dependencyNames).to.eql(['condition', 'someInterfaceVariable1']);
         });
     });
 
     describe('source', () => {
         it('is well formed', () => {
-            const a = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.Interface(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
+            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const whileStmt = new cgl.While(
                 new cgl.Reference(a),
                 new cgl.Block([


### PR DESCRIPTION
### Issue

#3 

### Usage
Adds a `SyntaxNode` for structs with the following usage:
```js
const structure = new cgl.Struct(qualifier, 'structName', variables);

/**
 * structure.source() =>
 * ----------------------------
 *
 * <qualifierType> struct structName {
 *   // variables
 * };
 */