### PR TITLE
'And' and 'Or' Operators

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -22,8 +22,8 @@ export default class Block implements Expression {
 
     public dependencies(): Set<InterfaceVariable> {
         return this.statements.reduce((union, statement) => (
-            union.addAll(statement.dependencies())
-        ),
+                union.addAll(statement.dependencies())
+            ),
             new Set<InterfaceVariable>()
         );
     }

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,4 +1,4 @@
-import Expression from './expression';
+import Expression from './expressions/expression';
 import InterfaceVariable from './interface';
 import Set from './util/set';
 import Statement from './statement';
@@ -22,8 +22,8 @@ export default class Block implements Expression {
 
     public dependencies(): Set<InterfaceVariable> {
         return this.statements.reduce((union, statement) => (
-                union.addAll(statement.dependencies())
-            ),
+            union.addAll(statement.dependencies())
+        ),
             new Set<InterfaceVariable>()
         );
     }

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -25,6 +25,8 @@
 export { default as Variable } from './variable';
 export { default as SyntaxNode } from './syntaxnode';
 export { default as Expression } from './expressions/expression';
+export { default as AndExpression } from './expressions/boolean/and_expression';
+export { default as OrExpression } from './expressions/boolean/or_expression';
 export { default as Statement } from './statement';
 export { default as Assignment } from './expressions/assignment';
 export { default as Function } from './function';

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -24,9 +24,9 @@
 
 export { default as Variable } from './variable';
 export { default as SyntaxNode } from './syntaxnode';
-export { default as Expression } from './expression';
+export { default as Expression } from './expressions/expression';
 export { default as Statement } from './statement';
-export { default as Assignment } from './assignment';
+export { default as Assignment } from './expressions/assignment';
 export { default as Function } from './function';
 export { default as Reference } from './reference';
 export { default as Shader } from './shader';

--- a/src/expressions/assignment.ts
+++ b/src/expressions/assignment.ts
@@ -1,15 +1,17 @@
 import Expression from './expression';
-import InterfaceVariable from './interface';
-import Reference from './reference';
-import Set from './util/set';
-import Type from './type';
+import InterfaceVariable from '../interface';
+import Reference from '../reference';
+import Set from '../util/set';
+import Type from '../type';
 
 export default class Assignment implements Expression {
     private lhs: Reference;
     private rhs: Expression;
 
-    // TODO: check that lhs and rhs types match
     constructor(lhs: Reference, rhs: Expression) {
+        if (lhs.returnType() != rhs.returnType())
+            throw new TypeError("Left-hand side and right-hand side do not match types.");
+
         this.lhs = lhs;
         this.rhs = rhs;
     }

--- a/src/expressions/boolean/and_expression.ts
+++ b/src/expressions/boolean/and_expression.ts
@@ -1,0 +1,30 @@
+import Expression from '../expression';
+import InterfaceVariable from '../../interface';
+import Reference from '../../reference';
+import Set from '../../util/set';
+import Type from '../../type';
+
+export default class AndExpression implements Expression {
+    private lhs: Reference;
+    private rhs: Expression;
+
+    constructor(lhs: Reference, rhs: Expression) {
+        if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
+            throw new TypeError("Not a boolean expression");
+
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.rhs.dependencies().union(this.lhs.dependencies());
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} && ${this.rhs.source()}`;
+    }
+
+    public returnType(): Type {
+        return Type.Bool;
+    }
+}

--- a/src/expressions/boolean/and_expression.ts
+++ b/src/expressions/boolean/and_expression.ts
@@ -9,6 +9,7 @@ export default class AndExpression implements Expression {
     private rhs: Expression;
 
     constructor(lhs: Expression, rhs: Expression) {
+        // TODO: add bool casting
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
 

--- a/src/expressions/boolean/and_expression.ts
+++ b/src/expressions/boolean/and_expression.ts
@@ -5,10 +5,10 @@ import Set from '../../util/set';
 import Type from '../../type';
 
 export default class AndExpression implements Expression {
-    private lhs: Reference;
+    private lhs: Expression;
     private rhs: Expression;
 
-    constructor(lhs: Reference, rhs: Expression) {
+    constructor(lhs: Expression, rhs: Expression) {
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
 
@@ -21,7 +21,7 @@ export default class AndExpression implements Expression {
     }
 
     public source(): string {
-        return `${this.lhs.source()} && ${this.rhs.source()}`;
+        return `(${this.lhs.source()} && ${this.rhs.source()})`;
     }
 
     public returnType(): Type {

--- a/src/expressions/boolean/or_expression.ts
+++ b/src/expressions/boolean/or_expression.ts
@@ -9,6 +9,7 @@ export default class OrExpression implements Expression {
     private rhs: Expression;
 
     constructor(lhs: Expression, rhs: Expression) {
+        // TODO: add bool casting
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
 

--- a/src/expressions/boolean/or_expression.ts
+++ b/src/expressions/boolean/or_expression.ts
@@ -5,10 +5,10 @@ import Set from '../../util/set';
 import Type from '../../type';
 
 export default class OrExpression implements Expression {
-    private lhs: Reference;
+    private lhs: Expression;
     private rhs: Expression;
 
-    constructor(lhs: Reference, rhs: Expression) {
+    constructor(lhs: Expression, rhs: Expression) {
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
 
@@ -21,7 +21,7 @@ export default class OrExpression implements Expression {
     }
 
     public source(): string {
-        return `${this.lhs.source()} || ${this.rhs.source()}`;
+        return `(${this.lhs.source()} || ${this.rhs.source()})`;
     }
 
     public returnType(): Type {

--- a/src/expressions/boolean/or_expression.ts
+++ b/src/expressions/boolean/or_expression.ts
@@ -1,0 +1,30 @@
+import Expression from '../expression';
+import InterfaceVariable from '../../interface';
+import Reference from '../../reference';
+import Set from '../../util/set';
+import Type from '../../type';
+
+export default class OrExpression implements Expression {
+    private lhs: Reference;
+    private rhs: Expression;
+
+    constructor(lhs: Reference, rhs: Expression) {
+        if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
+            throw new TypeError("Not a boolean expression");
+
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.rhs.dependencies().union(this.lhs.dependencies());
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} || ${this.rhs.source()}`;
+    }
+
+    public returnType(): Type {
+        return Type.Bool;
+    }
+}

--- a/src/expressions/expression.ts
+++ b/src/expressions/expression.ts
@@ -1,5 +1,5 @@
-import Type from './type';
-import SyntaxNode from './syntaxnode';
+import Type from '../type';
+import SyntaxNode from '../syntaxnode';
 
 export default interface Expression extends SyntaxNode {
     returnType(): Type;

--- a/src/if.ts
+++ b/src/if.ts
@@ -1,5 +1,5 @@
 import Block from './block';
-import Expression from './expression';
+import Expression from './expressions/expression';
 import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -1,0 +1,28 @@
+import Expression from './expressions/expression';
+import InterfaceVariable from './interface';
+import Reference from './reference';
+import Set from './util/set';
+import Type from './type';
+
+export default class Operator implements Expression {
+    private lhs: Reference;
+    private rhs: Expression;
+
+    // TODO: check that lhs and rhs types match
+    constructor(lhs: Reference, rhs: Expression) {
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.rhs.dependencies().union(this.lhs.dependencies());
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} = ${this.rhs.source()}`;
+    }
+
+    public returnType(): Type {
+        return Type.Bool;
+    }
+}

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,4 +1,4 @@
-import Expression from './expression';
+import Expression from './expressions/expression';
 import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';

--- a/src/while.ts
+++ b/src/while.ts
@@ -1,5 +1,5 @@
 import Block from './block';
-import Expression from './expression';
+import Expression from './expressions/expression';
 import InterfaceVariable from './interface';
 import Set from './util/set';
 import Type from './type';

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -47,9 +47,11 @@ describe('If', () => {
     });
 
     describe('source', () => {
+        const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
+        const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
+        const c = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'c'));
+
         it('has no else block if none is provided', () => {
-            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([
@@ -61,12 +63,8 @@ describe('If', () => {
 
             expect(ifStmt.source()).to.equalIgnoreSpaces('if (a) { a=b; }');
         });
-    });
 
-    describe('source', () => {
         it('has no else block if an empty block is provided', () => {
-            const a = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'));
-            const b = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'));
             const ifStmt = new cgl.If(
                 new cgl.Reference(a),
                 new cgl.Block([
@@ -78,6 +76,50 @@ describe('If', () => {
             );
 
             expect(ifStmt.source()).to.equalIgnoreSpaces('if (a) { a=b; }');
+        });
+
+        describe('operators', () => {
+            it('and', () => {
+                const ifStmt = new cgl.If(
+                    new cgl.AndExpression(new cgl.Reference(a), new cgl.Reference(b)),
+                    new cgl.Block([
+                        new cgl.Statement(
+                            new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        )
+                    ]),
+                    new cgl.Block()
+                );
+
+                expect(ifStmt.source()).to.equalIgnoreSpaces('if ((a && b)) { a=b; }');
+            });
+
+            it('or', () => {
+                const ifStmt = new cgl.If(
+                    new cgl.OrExpression(new cgl.Reference(a), new cgl.Reference(b)),
+                    new cgl.Block([
+                        new cgl.Statement(
+                            new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        )
+                    ]),
+                    new cgl.Block()
+                );
+
+                expect(ifStmt.source()).to.equalIgnoreSpaces('if ((a || b)) { a=b; }');
+            });
+
+            it('nested', () => {
+                const ifStmt = new cgl.If(
+                    new cgl.AndExpression(new cgl.Reference(a), new cgl.OrExpression(new cgl.Reference(b), new cgl.Reference(c))),
+                    new cgl.Block([
+                        new cgl.Statement(
+                            new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        )
+                    ]),
+                    new cgl.Block()
+                );
+
+                expect(ifStmt.source()).to.equalIgnoreSpaces('if ( ( a && (b || c) ) ) { a=b; }');
+            });
         });
     });
 });


### PR DESCRIPTION
#3, #26 

### Usage

Adds `&&` and `||` operators:
```js
// Declare boolean refrences
const a = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'))
);
const b = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'))
);
const c = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'c'))
);

// Or expression
// (a || b)
new cgl.OrExpression(a, b);

// And expression
// (a && b)
new cgl.AndExpression(a, b);

// Nested expression
// (a && (b || c))
new cgl.AndExpression(a, new cgl.OrExpression(b, c));
```