### PR TITLE
Not equal and Equal Expressions

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -25,8 +25,11 @@
 export { default as Variable } from './variable';
 export { default as SyntaxNode } from './syntaxnode';
 export { default as Expression } from './expressions/expression';
+export { default as BooleanExpression } from './expressions/boolean/boolean_expression';
 export { default as AndExpression } from './expressions/boolean/and_expression';
 export { default as OrExpression } from './expressions/boolean/or_expression';
+export { default as EqualExpression } from './expressions/boolean/equal_expression';
+export { default as NotEqualExpression } from './expressions/boolean/not_equal_expression';
 export { default as Statement } from './statement';
 export { default as Assignment } from './expressions/assignment';
 export { default as Function } from './function';

--- a/src/expressions/boolean/and_expression.ts
+++ b/src/expressions/boolean/and_expression.ts
@@ -1,31 +1,17 @@
+import BooleanExpression from './boolean_expression';
 import Expression from '../expression';
-import InterfaceVariable from '../../interface';
-import Reference from '../../reference';
-import Set from '../../util/set';
 import Type from '../../type';
 
-export default class AndExpression implements Expression {
-    private lhs: Expression;
-    private rhs: Expression;
-
+export default class AndExpression extends BooleanExpression {
     constructor(lhs: Expression, rhs: Expression) {
+        super(lhs, rhs);
+
         // TODO: add bool casting
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
-
-        this.lhs = lhs;
-        this.rhs = rhs;
-    }
-
-    public dependencies(): Set<InterfaceVariable> {
-        return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 
     public source(): string {
         return `(${this.lhs.source()} && ${this.rhs.source()})`;
-    }
-
-    public returnType(): Type {
-        return Type.Bool;
     }
 }

--- a/src/expressions/boolean/boolean_expression.ts
+++ b/src/expressions/boolean/boolean_expression.ts
@@ -1,0 +1,28 @@
+import Expression from '../expression';
+import InterfaceVariable from '../../interface';
+import Reference from '../../reference';
+import Set from '../../util/set';
+import Type from '../../type';
+
+export default abstract class BooleanExpression implements Expression {
+    protected lhs: Expression;
+    protected rhs: Expression;
+
+    constructor(lhs: Expression, rhs: Expression) {
+        if (lhs.returnType() != rhs.returnType())
+            throw new TypeError("Left-hand side and right-hand side do not match types.");
+
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.rhs.dependencies().union(this.lhs.dependencies());
+    }
+
+    public abstract source(): string;
+
+    public returnType(): Type {
+        return Type.Bool;
+    }
+}

--- a/src/expressions/boolean/equal_expression.ts
+++ b/src/expressions/boolean/equal_expression.ts
@@ -1,0 +1,12 @@
+import BooleanExpression from './boolean_expression';
+import Expression from '../expression';
+
+export default class EqualExpression extends BooleanExpression {
+    constructor(lhs: Expression, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `(${this.lhs.source()} == ${this.rhs.source()})`;
+    }
+}

--- a/src/expressions/boolean/not_equal_expression.ts
+++ b/src/expressions/boolean/not_equal_expression.ts
@@ -1,0 +1,12 @@
+import BooleanExpression from './boolean_expression';
+import Expression from '../expression';
+
+export default class NotEqualExpression extends BooleanExpression {
+    constructor(lhs: Expression, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `(${this.lhs.source()} != ${this.rhs.source()})`;
+    }
+}

--- a/src/expressions/boolean/or_expression.ts
+++ b/src/expressions/boolean/or_expression.ts
@@ -1,31 +1,17 @@
+import BooleanExpression from './boolean_expression';
 import Expression from '../expression';
-import InterfaceVariable from '../../interface';
-import Reference from '../../reference';
-import Set from '../../util/set';
 import Type from '../../type';
 
-export default class OrExpression implements Expression {
-    private lhs: Expression;
-    private rhs: Expression;
-
+export default class OrExpression extends BooleanExpression {
     constructor(lhs: Expression, rhs: Expression) {
+        super(lhs, rhs);
+
         // TODO: add bool casting
         if (lhs.returnType() != Type.Bool || rhs.returnType() != Type.Bool)
             throw new TypeError("Not a boolean expression");
-
-        this.lhs = lhs;
-        this.rhs = rhs;
-    }
-
-    public dependencies(): Set<InterfaceVariable> {
-        return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 
     public source(): string {
         return `(${this.lhs.source()} || ${this.rhs.source()})`;
-    }
-
-    public returnType(): Type {
-        return Type.Bool;
     }
 }

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -107,6 +107,35 @@ describe('If', () => {
                 expect(ifStmt.source()).to.equalIgnoreSpaces('if ((a || b)) { a=b; }');
             });
 
+            it('equal', () => {
+                const ifStmt = new cgl.If(
+                    new cgl.EqualExpression(new cgl.Reference(a), new cgl.Reference(b)),
+                    new cgl.Block([
+                        new cgl.Statement(
+                            new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        )
+                    ]),
+                    new cgl.Block()
+                );
+
+                expect(ifStmt.source()).to.equalIgnoreSpaces('if ((a == b)) { a=b; }');
+            });
+
+
+            it('not equal', () => {
+                const ifStmt = new cgl.If(
+                    new cgl.NotEqualExpression(new cgl.Reference(a), new cgl.Reference(b)),
+                    new cgl.Block([
+                        new cgl.Statement(
+                            new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        )
+                    ]),
+                    new cgl.Block()
+                );
+
+                expect(ifStmt.source()).to.equalIgnoreSpaces('if ((a != b)) { a=b; }');
+            });
+
             it('nested', () => {
                 const ifStmt = new cgl.If(
                     new cgl.AndExpression(new cgl.Reference(a), new cgl.OrExpression(new cgl.Reference(b), new cgl.Reference(c))),


### PR DESCRIPTION
#3, #26

### Changes

- Refactored boolean expressions by making abstract 'BooleanExpression' class.
- Added 'equal' and 'not equal' expressions.

### Usage

Adds `==` and `!=` operators

```js
// Declare boolean refrences
const a = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'a'))
);
const b = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Bool, 'b'))
);

// Equal expression
// (a == b)
new cgl.EqualExpression(a, b);

// And expression
// (a != b)
new cgl.NotEqualExpression(a, b);
```