### PR TITLE
Added assignment expressions.

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -24,7 +24,18 @@
 
 export { default as Variable } from './variable';
 export { default as SyntaxNode } from './syntaxnode';
+
 export { default as Expression } from './expressions/expression';
+
+// Assignment Expressions
+export { default as Assignment } from './expressions/assignment/assignment';
+export { default as EqualAssignment } from './expressions/assignment/equal_assignment';
+export { default as PlusEqualAssignment } from './expressions/assignment/plus_equal_assignment';
+export { default as MinusEqualAssignment } from './expressions/assignment/minus_equal_assignment';
+export { default as TimesEqualAssignment } from './expressions/assignment/times_equal_assignment';
+export { default as DivideEqualAssignment } from './expressions/assignment/divide_equal_assignment';
+
+// Boolean Expressions
 export { default as BooleanExpression } from './expressions/boolean/boolean_expression';
 export { default as AndExpression } from './expressions/boolean/and_expression';
 export { default as OrExpression } from './expressions/boolean/or_expression';
@@ -35,8 +46,8 @@ export { default as LessThanExpression } from './expressions/boolean/less_than_e
 export { default as LessThanEqualExpression } from './expressions/boolean/less_than_equal_expression';
 export { default as GreaterThanExpression } from './expressions/boolean/greater_than_expression';
 export { default as GreaterThanEqualExpression } from './expressions/boolean/greater_than_equal_expression';
+
 export { default as Statement } from './statement';
-export { default as Assignment } from './expressions/assignment';
 export { default as Function } from './function';
 export { default as Reference } from './reference';
 export { default as Shader } from './shader';

--- a/src/expressions/assignment/assignment.ts
+++ b/src/expressions/assignment/assignment.ts
@@ -1,12 +1,12 @@
-import Expression from './expression';
-import InterfaceVariable from '../interface';
-import Reference from '../reference';
-import Set from '../util/set';
-import Type from '../type';
+import Expression from '../expression';
+import InterfaceVariable from '../../interface';
+import Reference from '../../reference';
+import Set from '../../util/set';
+import Type from '../../type';
 
-export default class Assignment implements Expression {
-    private lhs: Reference;
-    private rhs: Expression;
+export default abstract class AssignmentExpression implements Expression {
+    protected lhs: Reference;
+    protected rhs: Expression;
 
     constructor(lhs: Reference, rhs: Expression) {
         if (lhs.returnType() != rhs.returnType())
@@ -20,9 +20,7 @@ export default class Assignment implements Expression {
         return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 
-    public source(): string {
-        return `${this.lhs.source()} = ${this.rhs.source()}`;
-    }
+    public abstract source(): string;
 
     public returnType(): Type {
         return this.lhs.returnType();

--- a/src/expressions/assignment/divide_equal_assignment.ts
+++ b/src/expressions/assignment/divide_equal_assignment.ts
@@ -2,7 +2,7 @@ import AssignmentExpression from './assignment'
 import Expression from '../expression';
 import Reference from '../../reference';
 
-export default abstract class DivideEqualAssignment extends AssignmentExpression {
+export default class DivideEqualAssignment extends AssignmentExpression {
     constructor(lhs: Reference, rhs: Expression) {
         super(lhs, rhs);
     }

--- a/src/expressions/assignment/divide_equal_assignment.ts
+++ b/src/expressions/assignment/divide_equal_assignment.ts
@@ -1,0 +1,13 @@
+import AssignmentExpression from './assignment'
+import Expression from '../expression';
+import Reference from '../../reference';
+
+export default abstract class DivideEqualAssignment extends AssignmentExpression {
+    constructor(lhs: Reference, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} /= ${this.rhs.source()}`;
+    }
+}

--- a/src/expressions/assignment/equal_assignment.ts
+++ b/src/expressions/assignment/equal_assignment.ts
@@ -1,0 +1,13 @@
+import AssignmentExpression from './assignment'
+import Expression from '../expression';
+import Reference from '../../reference';
+
+export default abstract class EqualAssignment extends AssignmentExpression {
+    constructor(lhs: Reference, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} = ${this.rhs.source()}`;
+    }
+}

--- a/src/expressions/assignment/equal_assignment.ts
+++ b/src/expressions/assignment/equal_assignment.ts
@@ -2,7 +2,7 @@ import AssignmentExpression from './assignment'
 import Expression from '../expression';
 import Reference from '../../reference';
 
-export default abstract class EqualAssignment extends AssignmentExpression {
+export default class EqualAssignment extends AssignmentExpression {
     constructor(lhs: Reference, rhs: Expression) {
         super(lhs, rhs);
     }

--- a/src/expressions/assignment/minus_equal_assignment.ts
+++ b/src/expressions/assignment/minus_equal_assignment.ts
@@ -1,0 +1,13 @@
+import AssignmentExpression from './assignment'
+import Expression from '../expression';
+import Reference from '../../reference';
+
+export default abstract class MinusEqualAssignment extends AssignmentExpression {
+    constructor(lhs: Reference, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} -= ${this.rhs.source()}`;
+    }
+}

--- a/src/expressions/assignment/minus_equal_assignment.ts
+++ b/src/expressions/assignment/minus_equal_assignment.ts
@@ -2,7 +2,7 @@ import AssignmentExpression from './assignment'
 import Expression from '../expression';
 import Reference from '../../reference';
 
-export default abstract class MinusEqualAssignment extends AssignmentExpression {
+export default class MinusEqualAssignment extends AssignmentExpression {
     constructor(lhs: Reference, rhs: Expression) {
         super(lhs, rhs);
     }

--- a/src/expressions/assignment/plus_equal_assignment.ts
+++ b/src/expressions/assignment/plus_equal_assignment.ts
@@ -1,0 +1,13 @@
+import AssignmentExpression from './assignment'
+import Expression from '../expression';
+import Reference from '../../reference';
+
+export default abstract class PlusEqualAssignment extends AssignmentExpression {
+    constructor(lhs: Reference, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} += ${this.rhs.source()}`;
+    }
+}

--- a/src/expressions/assignment/plus_equal_assignment.ts
+++ b/src/expressions/assignment/plus_equal_assignment.ts
@@ -2,7 +2,7 @@ import AssignmentExpression from './assignment'
 import Expression from '../expression';
 import Reference from '../../reference';
 
-export default abstract class PlusEqualAssignment extends AssignmentExpression {
+export default class PlusEqualAssignment extends AssignmentExpression {
     constructor(lhs: Reference, rhs: Expression) {
         super(lhs, rhs);
     }

--- a/src/expressions/assignment/times_equal_assignment.ts
+++ b/src/expressions/assignment/times_equal_assignment.ts
@@ -1,0 +1,13 @@
+import AssignmentExpression from './assignment'
+import Expression from '../expression';
+import Reference from '../../reference';
+
+export default abstract class TimesEqualAssignment extends AssignmentExpression {
+    constructor(lhs: Reference, rhs: Expression) {
+        super(lhs, rhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()} *= ${this.rhs.source()}`;
+    }
+}

--- a/src/expressions/assignment/times_equal_assignment.ts
+++ b/src/expressions/assignment/times_equal_assignment.ts
@@ -2,7 +2,7 @@ import AssignmentExpression from './assignment'
 import Expression from '../expression';
 import Reference from '../../reference';
 
-export default abstract class TimesEqualAssignment extends AssignmentExpression {
+export default class TimesEqualAssignment extends AssignmentExpression {
     constructor(lhs: Reference, rhs: Expression) {
         super(lhs, rhs);
     }

--- a/test/assignment.spec.js
+++ b/test/assignment.spec.js
@@ -2,20 +2,43 @@ import { expect } from 'chai';
 import * as cgl from '../src/calder';
 
 describe('Assignment', () => {
+    const lhs = new cgl.Reference(new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs')));
+    const rhs = new cgl.Reference(new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs')));
+
     describe('dependencies', () => {
         it('references both the left and right hand sides', () => {
-            const assignment = new cgl.Assignment(
-                new cgl.Reference(
-                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs'))
-                ),
-                new cgl.Reference(
-                    new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs'))
-                )
-            );
+            const assignment = new cgl.EqualAssignment(lhs, rhs);
 
             expect(
                 [...assignment.dependencies()].map(dep => dep.name).sort()
             ).to.eql(['lhs', 'rhs']);
+        });
+    });
+
+    describe('source', () => {
+        it ('equal assignment', () => {
+            const assignment = new cgl.EqualAssignment(lhs, rhs);
+            expect(assignment.source()).to.equalIgnoreSpaces('lhs = rhs');
+        });
+
+        it ('plus equal assignment', () => {
+            const assignment = new cgl.PlusEqualAssignment(lhs, rhs);
+            expect(assignment.source()).to.equalIgnoreSpaces('lhs += rhs');
+        });
+
+        it ('minus equal assignment', () => {
+            const assignment = new cgl.MinusEqualAssignment(lhs, rhs);
+            expect(assignment.source()).to.equalIgnoreSpaces('lhs -= rhs');
+        });
+
+        it ('times equal assignment', () => {
+            const assignment = new cgl.TimesEqualAssignment(lhs, rhs);
+            expect(assignment.source()).to.equalIgnoreSpaces('lhs *= rhs');
+        });
+
+        it ('divide equal assignment', () => {
+            const assignment = new cgl.DivideEqualAssignment(lhs, rhs);
+            expect(assignment.source()).to.equalIgnoreSpaces('lhs /= rhs');
         });
     });
 });

--- a/test/dowhile.spec.js
+++ b/test/dowhile.spec.js
@@ -10,7 +10,7 @@ describe('DoWhile', () => {
                 new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
+                        new cgl.EqualAssignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -30,7 +30,7 @@ describe('DoWhile', () => {
                 new cgl.Reference(a),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        new cgl.EqualAssignment(new cgl.Reference(a), new cgl.Reference(b))
                     )
                 ])
             );

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -11,12 +11,12 @@ describe('If', () => {
                 new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
+                        new cgl.EqualAssignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ]),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable2))
+                        new cgl.EqualAssignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable2))
                     )
                 ])
             );
@@ -34,7 +34,7 @@ describe('If', () => {
                 new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
+                        new cgl.EqualAssignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -56,7 +56,7 @@ describe('If', () => {
                 new cgl.Reference(a),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        new cgl.EqualAssignment(new cgl.Reference(a), new cgl.Reference(b))
                     )
                 ])
             );
@@ -69,7 +69,7 @@ describe('If', () => {
                 new cgl.Reference(a),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        new cgl.EqualAssignment(new cgl.Reference(a), new cgl.Reference(b))
                     )
                 ]),
                 new cgl.Block()

--- a/test/shader.spec.js
+++ b/test/shader.spec.js
@@ -11,7 +11,7 @@ function basicShader() {
     const shader = new cgl.Shader(
         new cgl.Function('main', [
             new cgl.Statement(
-                new cgl.Assignment(
+                new cgl.EqualAssignment(
                     new cgl.Reference(glPosition),
                     new cgl.Reference(vertexPosition)
                 )

--- a/test/while.spec.js
+++ b/test/while.spec.js
@@ -10,7 +10,7 @@ describe('While', () => {
                 new cgl.Reference(conditionInterfaceVariable),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
+                        new cgl.EqualAssignment(new cgl.Reference(conditionInterfaceVariable), new cgl.Reference(someInterfaceVariable1))
                     )
                 ])
             );
@@ -30,7 +30,7 @@ describe('While', () => {
                 new cgl.Reference(a),
                 new cgl.Block([
                     new cgl.Statement(
-                        new cgl.Assignment(new cgl.Reference(a), new cgl.Reference(b))
+                        new cgl.EqualAssignment(new cgl.Reference(a), new cgl.Reference(b))
                     )
                 ])
             );


### PR DESCRIPTION
#3, #26

### Changes
- Renamed `Assignment` to `EqualAssignment`.
- [x] +=
- [x] -=
- [x] *=
- [x] /=

### Usage

Adds `+=`, `-=`, `*=`, and `/=` operators

```js
// Declare references
const lhs = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'lhs'))
);
const rhs = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Vec4, 'rhs'))
);

// EqualAssignment expression
// lhs = rhs
new cgl.EqualAssignment(lhs, rhs);

// PlusEqualAssignment expression
// lhs += rhs
new cgl.PlusEqualAssignment(lhs, rhs);

// MinusEqualAssignment expression
// lhs -= rhs
new cgl.MinusEqualAssignment(lhs, rhs);

// TimesEqualAssignment expression
// lhs =* rhs
new cgl.TimesEqualAssignment(lhs, rhs);

// DivideEqualAssignment expression
// lhs /= rhs
new cgl.DivideEqualAssignment(lhs, rhs);
```