### PR TITLE
Added unary expressions.

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -25,6 +25,10 @@
 export { default as Variable } from './variable';
 export { default as SyntaxNode } from './syntaxnode';
 
+/*****************************
+ * Expressions
+ *****************************/
+
 export { default as Expression } from './expressions/expression';
 
 // Assignment Expressions
@@ -46,6 +50,17 @@ export { default as LessThanExpression } from './expressions/boolean/less_than_e
 export { default as LessThanEqualExpression } from './expressions/boolean/less_than_equal_expression';
 export { default as GreaterThanExpression } from './expressions/boolean/greater_than_expression';
 export { default as GreaterThanEqualExpression } from './expressions/boolean/greater_than_equal_expression';
+
+// Unary Math Expressions
+export { default as UnaryExpression } from './expressions/math/unary/unary_expression';
+export { default as PrefixIncrement } from './expressions/math/unary/prefix_increment';
+export { default as PrefixDecrement } from './expressions/math/unary/prefix_decrement';
+export { default as PostfixIncrement } from './expressions/math/unary/postfix_increment';
+export { default as PostfixDecrement } from './expressions/math/unary/postfix_decrement';
+
+/*****************************
+ * Other
+ *****************************/
 
 export { default as Statement } from './statement';
 export { default as Function } from './function';

--- a/src/expressions/math/unary/postfix_decrement.ts
+++ b/src/expressions/math/unary/postfix_decrement.ts
@@ -1,0 +1,13 @@
+import UnaryExpression from './unary_expression'
+import Expression from '../../expression';
+import Reference from '../../../reference';
+
+export default class PostfixDecrement extends UnaryExpression {
+    constructor(lhs: Reference) {
+        super(lhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()}--`;
+    }
+}

--- a/src/expressions/math/unary/postfix_increment.ts
+++ b/src/expressions/math/unary/postfix_increment.ts
@@ -1,0 +1,13 @@
+import UnaryExpression from './unary_expression'
+import Expression from '../../expression';
+import Reference from '../../../reference';
+
+export default class PostfixIncrement extends UnaryExpression {
+    constructor(lhs: Reference) {
+        super(lhs);
+    }
+
+    public source(): string {
+        return `${this.lhs.source()}++`;
+    }
+}

--- a/src/expressions/math/unary/prefix_decrement.ts
+++ b/src/expressions/math/unary/prefix_decrement.ts
@@ -1,0 +1,13 @@
+import UnaryExpression from './unary_expression'
+import Expression from '../../expression';
+import Reference from '../../../reference';
+
+export default class PrefixDecrement extends UnaryExpression {
+    constructor(lhs: Reference) {
+        super(lhs);
+    }
+
+    public source(): string {
+        return `--${this.lhs.source()}`;
+    }
+}

--- a/src/expressions/math/unary/prefix_increment.ts
+++ b/src/expressions/math/unary/prefix_increment.ts
@@ -1,0 +1,13 @@
+import UnaryExpression from './unary_expression'
+import Expression from '../../expression';
+import Reference from '../../../reference';
+
+export default class PrefixIncrement extends UnaryExpression {
+    constructor(lhs: Reference) {
+        super(lhs);
+    }
+
+    public source(): string {
+        return `++${this.lhs.source()}`;
+    }
+}

--- a/src/expressions/math/unary/unary_expression.ts
+++ b/src/expressions/math/unary/unary_expression.ts
@@ -1,0 +1,29 @@
+import Expression from '../../expression';
+import InterfaceVariable from '../../../interface';
+import Qualifier from '../../../qualifier';
+import Reference from '../../../reference';
+import Set from '../../../util/set';
+import Type from '../../../type';
+
+export default abstract class UnaryExpression implements Expression {
+    protected lhs: Reference;
+
+    constructor(lhs: Reference) {
+        if (lhs.returnType() != Type.Int)
+            throw new TypeError('Can only perform unary expression on integer type.');
+        if (lhs.qualifier == Qualifier.Const)
+            throw new TypeError('Can\'t mutate constant variable.');
+
+        this.lhs = lhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.lhs.dependencies();
+    }
+
+    public abstract source(): string;
+
+    public returnType(): Type {
+        return Type.Int;
+    }
+}

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,12 +1,15 @@
 import Expression from './expressions/expression';
 import InterfaceVariable from './interface';
+import Qualifier from './qualifier';
 import Set from './util/set';
 import Type from './type';
 
 export default class Reference implements Expression {
+    public readonly qualifier: Qualifier;
     private variable: InterfaceVariable;
 
     constructor(variable: InterfaceVariable) {
+        this.qualifier = variable.qualifier;
         this.variable = variable;
     }
 

--- a/test/expressions/math/unary.spec.js
+++ b/test/expressions/math/unary.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import * as cgl from '../../../src/calder';
+
+describe('Unary Expressions', () => {
+    let lhs = new cgl.Reference(new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Int, 'lhs')));
+
+    describe('source', () => {
+        it ('prefix increment', () => {
+            const operation = new cgl.PrefixIncrement(lhs);
+            expect(operation.source()).to.equalIgnoreSpaces('++lhs');
+        });
+
+        it ('prefix decrement', () => {
+            const operation = new cgl.PrefixDecrement(lhs);
+            expect(operation.source()).to.equalIgnoreSpaces('--lhs');
+        });
+
+        it ('postfix increment', () => {
+            const operation = new cgl.PostfixIncrement(lhs);
+            expect(operation.source()).to.equalIgnoreSpaces('lhs++');
+        });
+
+        it ('postfix decrement', () => {
+            const operation = new cgl.PostfixDecrement(lhs);
+            expect(operation.source()).to.equalIgnoreSpaces('lhs--');
+        });
+    });
+
+    describe('errors', () => {
+        let constVar = new cgl.Reference(new cgl.InterfaceVariable(cgl.Qualifier.Const, new cgl.Variable(cgl.Type.Int, 'lhs')));
+        let stringVar = new cgl.Reference(new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.String, 'lhs')));
+
+        it ('throws error on mutation of const variable', () => {
+            expect(() => new cgl.PostfixDecrement(constVar))
+                .to.throw('Can\'t mutate constant variable.');
+        });
+
+        it ('throws error when type of reference is not integer', () => {
+            expect(() => new cgl.PostfixDecrement(stringVar))
+                .to.throw('Can only perform unary expression on integer type.');
+        });
+    });
+});


### PR DESCRIPTION
#3, #26

### Changes
- [x] ++
- [x] --

### Usage

Adds `++`, and `--` operators:

```js
// Declare reference
let lhs = new cgl.Reference(
  new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.Variable(cgl.Type.Int, 'lhs'))
);

// PrefixIncrement expression
// ++lhs
new cgl.PrefixIncrement(lhs);

// PrefixDecrement expression
// --lhs
new cgl.PrefixDecrement(lhs);

// PostfixIncrement expression
// lhs++
new cgl.PostfixIncrement(lhs);

// PostfixDecrement expression
// lhs--
new cgl.PostfixDecrement(lhs);
```