### PR TITLE
Children type validation

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -59,6 +59,12 @@ export { default as PostfixIncrement } from './expressions/math/unary/postfix_in
 export { default as PostfixDecrement } from './expressions/math/unary/postfix_decrement';
 
 /*****************************
+ * Exceptions
+ *****************************/
+
+export { default as TypeException } from './exceptions/typeexception';
+
+/*****************************
  * Other
  *****************************/
 

--- a/src/exceptions/typeexception.ts
+++ b/src/exceptions/typeexception.ts
@@ -1,0 +1,6 @@
+export default class TypeException extends Error {
+    constructor(m: string) {
+        super(m);
+        Object.setPrototypeOf(this, TypeException.prototype);
+    }
+}

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,5 @@
 import MetaKind from './metakind';
-import Kind from './kind';
+import TypeException from './exceptions/typeexception';
 
 export default class Type {
     public readonly name: string;
@@ -11,9 +11,24 @@ export default class Type {
         this.metakind = metakind;
         this.children = children;
 
-        // TODO: check that:
-        // a) metakind == Basic => children == []
-        // b) metakind == Array => children == [SomeType]
+        // Validate children types
+        switch (metakind) {
+            case MetaKind.Basic: {
+                if (children.length != 0) {
+                    throw new TypeException('Basic kind cannot have any children types.');
+                }
+                break;
+            }
+            case MetaKind.Array: {
+                if (children.length != 1) {
+                    throw new TypeException('Array kind must have exactly one child type.');
+                }
+                break;
+            }
+            default: {
+                break;
+            }
+        }
     }
 
     public checkEquals(otherType: Type): boolean {

--- a/test/type.spec.js
+++ b/test/type.spec.js
@@ -16,6 +16,14 @@ describe('Type', () => {
 
             expect(intType.checkEquals(floatType)).to.be.false;
         });
+
+        it('cannot have any children types', () => {
+            let childrenTypes = [new cgl.Type(cgl.Kind.Int)];
+
+            expect(() => {
+                let invalidArray = new cgl.Type('', cgl.MetaKind.Basic, childrenTypes);
+            }).to.throw(cgl.TypeException, 'Basic kind cannot have any children types.');
+        });
     });
 
     describe('array types', () => {
@@ -31,6 +39,14 @@ describe('Type', () => {
             const floatArrayType = new cgl.Type('', cgl.MetaKind.Array, [new cgl.Type(cgl.Kind.Float)]);
 
             expect(intArrayType.checkEquals(floatArrayType)).to.be.false;
+        });
+
+        it('must have exactly one child type upon initialization', () => {
+            let childrenTypes = [new cgl.Type(cgl.Kind.Int), new cgl.Type(cgl.Kind.Float)];
+
+            expect(() => {
+                let invalidArray = new cgl.Type('', cgl.MetaKind.Array, childrenTypes);
+            }).to.throw(cgl.TypeException, 'Array kind must have exactly one child type.');
         });
     });
 


### PR DESCRIPTION
This PR introduces the concept of exceptions too. We can have a discussion about this:

- Currently I'm inheriting from Error, and changing the prototype explicitly
- I put all exceptions in the exception folder
- I used the suffix naming convention 'Exception' rather than 'Error' like in most JS to further distinguish b/w JS errors and Calder errors.

Note: I've noticed that we've also used `TypeError` in other places. This is okay, but it comes with the tradeoff of users not knowing if they are passing in the wrong type into Calder or if they are using the Calder methods wrong. There's 2 layers of abstraction now so things get more complicated.

Further questions that came up while I was working on this PR:
- Do we want to check in the type class if the type name has already been used? We can maintain some static set of already used types if we want to do that.