### PR TITLE
Added comma expression

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -57,6 +57,9 @@ export { default as PrefixDecrement } from './expressions/math/unary/prefix_decr
 export { default as PostfixIncrement } from './expressions/math/unary/postfix_increment';
 export { default as PostfixDecrement } from './expressions/math/unary/postfix_decrement';
 
+// Other Expressions
+export { default as Comma } from './expressions/other/comma';
+
 /*****************************
  * Other
  *****************************/

--- a/src/expressions/other/comma.ts
+++ b/src/expressions/other/comma.ts
@@ -9,9 +9,6 @@ export default class Comma implements Expression {
     protected rhs: Expression;
 
     constructor(lhs: Reference, rhs: Expression) {
-        if (!lhs.returnType().checkEquals(rhs.returnType()))
-            throw new TypeError('Left-hand side and right-hand side do not match types.');
-
         this.lhs = lhs;
         this.rhs = rhs;
     }
@@ -21,6 +18,6 @@ export default class Comma implements Expression {
     }
 
     public returnType(): Type {
-        return this.lhs.returnType();
+        return this.rhs.returnType();
     }
 }

--- a/src/expressions/other/comma.ts
+++ b/src/expressions/other/comma.ts
@@ -1,0 +1,31 @@
+import Expression from '../expression';
+import InterfaceVariable from '../../interface';
+import Reference from '../../reference';
+import Set from '../../util/set';
+import Type from '../../type';
+import Kind from '../../kind';
+
+export default class Comma implements Expression {
+    protected lhs: Reference;
+    protected rhs: Reference;
+
+    constructor(lhs: Reference, rhs: Reference) {
+        if (!lhs.returnType().checkEquals(rhs.returnType()))
+            throw new TypeError("Left-hand side and right-hand side do not match types.");
+
+        this.lhs = lhs;
+        this.rhs = rhs;
+    }
+
+    public dependencies(): Set<InterfaceVariable> {
+        return this.rhs.dependencies().union(this.lhs.dependencies());
+    }
+
+    public source(): string {
+        return `${this.lhs.source()}, ${this.rhs.source()}`;
+    }
+
+    public returnType(): Type {
+        return this.lhs.returnType();
+    }
+}

--- a/src/expressions/other/comma.ts
+++ b/src/expressions/other/comma.ts
@@ -1,5 +1,4 @@
 import Expression from '../expression';
-import InterfaceVariable from '../../interface';
 import Reference from '../../reference';
 import Set from '../../util/set';
 import Type from '../../type';
@@ -7,18 +6,14 @@ import Kind from '../../kind';
 
 export default class Comma implements Expression {
     protected lhs: Reference;
-    protected rhs: Reference;
+    protected rhs: Expression;
 
-    constructor(lhs: Reference, rhs: Reference) {
+    constructor(lhs: Reference, rhs: Expression) {
         if (!lhs.returnType().checkEquals(rhs.returnType()))
-            throw new TypeError("Left-hand side and right-hand side do not match types.");
+            throw new TypeError('Left-hand side and right-hand side do not match types.');
 
         this.lhs = lhs;
         this.rhs = rhs;
-    }
-
-    public dependencies(): Set<InterfaceVariable> {
-        return this.rhs.dependencies().union(this.lhs.dependencies());
     }
 
     public source(): string {

--- a/test/expressions/other/other_expressions.spec.js
+++ b/test/expressions/other/other_expressions.spec.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import * as cgl from '../../../src/calder';
+
+describe('Other Expressions', () => {
+    let lhs = new cgl.Reference(
+        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), 'lhs'))
+    );
+    let rhs = new cgl.Reference(
+        new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), 'rhs'))
+    );
+
+    describe('Comma', () => {
+        describe('source', () => {
+            it ('returns a comma separated list', () => {
+                const operation = new cgl.Comma(lhs, rhs);
+                expect(operation.source()).to.equalIgnoreSpaces('lhs, rhs');
+            });
+        });
+
+        describe('errors', () => {
+            let stringVar = new cgl.Reference(
+                new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.String), 'rhs'))
+            );
+
+            it ('throws error when type of reference is not integer', () => {
+                expect(() => new cgl.Comma(lhs, stringVar))
+                    .to.throw('Left-hand side and right-hand side do not match types.');
+            });
+        });
+    });
+});

--- a/test/expressions/other/other_expressions.spec.js
+++ b/test/expressions/other/other_expressions.spec.js
@@ -16,16 +16,5 @@ describe('Other Expressions', () => {
                 expect(operation.source()).to.equalIgnoreSpaces('lhs, rhs');
             });
         });
-
-        describe('errors', () => {
-            let stringVar = new cgl.Reference(
-                new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.String), 'rhs'))
-            );
-
-            it ('throws error when type of reference is not integer', () => {
-                expect(() => new cgl.Comma(lhs, stringVar))
-                    .to.throw('Left-hand side and right-hand side do not match types.');
-            });
-        });
     });
 });


### PR DESCRIPTION
#3, #26

### Changes
- [x] ,

### Usage

Adds the `,` operator:

```js
// Declare references
let lhs = new cgl.Reference(
  new cgl.InterfaceVariable(
    cgl.Qualifier.In, new cgl.Variable(new cgl.Type(cgl.Kind.String), 'lhs')
  )
);
let rhs = new cgl.Reference(
  new cgl.InterfaceVariable(
    cgl.Qualifier.In, new cgl.Variable(new cgl.Type(cgl.Kind.String), 'rhs')
  )
);

// Comma expression
// lhs, rhs
new cgl.Comma(lhs, rhs);
```