### PR TITLE
Handles different return types.

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -65,6 +65,7 @@ export { default as Comma } from './expressions/other/comma';
  *****************************/
 
 export { default as Statement } from './statement';
+export { default as ReturnStatement } from './return_statement';
 export { default as Function } from './function';
 export { default as Reference } from './reference';
 export { default as VariableDeclaration } from './variabledeclaration';

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,19 +1,21 @@
+import Kind from './kind';
 import Set from './util/set';
 import Statement from './statement';
 import SyntaxNode from './syntaxnode';
 
 export default class Function implements SyntaxNode {
     public readonly name: string;
+    public readonly returnType: Kind;
     private statements: Statement[];
 
-    constructor(name: string, statements: Statement[] = []) {
+    constructor(name: string, statements: Statement[] = [], returnType: Kind = Kind.Void) {
         this.name = name;
         this.statements = statements;
+        this.returnType = returnType;
     }
 
     public source(): string {
-        // TODO: allow more than void()
-        return `void ${this.name}() {\n
+        return `${this.returnType} ${this.name}() {\n
             ${this.statements
                 .map(statement => statement.source())
                 .join('\n')}\n

--- a/src/return_statement.ts
+++ b/src/return_statement.ts
@@ -1,0 +1,15 @@
+import InterfaceVariable from './interfacevariable';
+import Set from './util/set';
+import SyntaxNode from './syntaxnode';
+
+export default class ReturnStatement implements SyntaxNode {
+    private node: SyntaxNode;
+
+    constructor(node: SyntaxNode) {
+        this.node = node;
+    }
+
+    public source(): string {
+        return `return ${this.node.source()};`;
+    }
+}

--- a/src/return_statement.ts
+++ b/src/return_statement.ts
@@ -1,18 +1,21 @@
+import Expression from './expressions/expression';
 import InterfaceVariable from './interfacevariable';
-import Kind from './kind';
 import Set from './util/set';
 import SyntaxNode from './syntaxnode';
+import Type from './type';
 
-export default class ReturnStatement implements SyntaxNode {
-    private node: SyntaxNode;
-    public readonly returnType: Kind;
+export default class ReturnStatement implements Expression {
+    private expression: Expression;
 
-    constructor(node: SyntaxNode, returnType: Kind) {
-        this.node = node;
-        this.returnType = returnType;
+    constructor(expression: Expression) {
+        this.expression = expression;
     }
 
     public source(): string {
-        return `return ${this.node.source()};`;
+        return `return ${this.expression.source()};`;
+    }
+
+    public returnType(): Type {
+        return this.expression.returnType();
     }
 }

--- a/src/return_statement.ts
+++ b/src/return_statement.ts
@@ -1,12 +1,15 @@
 import InterfaceVariable from './interfacevariable';
+import Kind from './kind';
 import Set from './util/set';
 import SyntaxNode from './syntaxnode';
 
 export default class ReturnStatement implements SyntaxNode {
     private node: SyntaxNode;
+    public readonly returnType: Kind;
 
-    constructor(node: SyntaxNode) {
+    constructor(node: SyntaxNode, returnType: Kind) {
         this.node = node;
+        this.returnType = returnType;
     }
 
     public source(): string {

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -30,7 +30,7 @@ describe('Function', () => {
 
         it('handles different return types', () => {
             const test = new cgl.Function(
-                'test', [new cgl.ReturnStatement(new cgl.Reference(integerVar), cgl.Kind.Int)], cgl.Kind.Int
+                'test', [new cgl.ReturnStatement(new cgl.Reference(integerVar))], cgl.Kind.Int
             );
 
             expect(test.source()).to.equalIgnoreSpaces(`int test() {

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -3,9 +3,11 @@ import * as cgl from '../src/calder';
 
 describe('Function', () => {
     describe('source', () => {
+        const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'gl_Position'));
+        const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'vertexPosition'));
+        const integerVar = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), '0'));
+
         it('creates the correct source', () => {
-            const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'gl_Position'));
-            const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'vertexPosition'));
             const main = new cgl.Function('main', [
                 new cgl.Statement(
                     new cgl.EqualAssignment(
@@ -17,6 +19,16 @@ describe('Function', () => {
 
             expect(main.source()).to.equalIgnoreSpaces(`void main() {
                 gl_Position = vertexPosition;
+            }`);
+        });
+
+        it('handles different return types', () => {
+            const test = new cgl.Function('test', [
+                new cgl.ReturnStatement(new cgl.Reference(integerVar)),
+            ], cgl.Kind.Int);
+
+            expect(test.source()).to.equalIgnoreSpaces(`int test() {
+                return 0;
             }`);
         });
     });

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -29,7 +29,9 @@ describe('Function', () => {
         });
 
         it('handles different return types', () => {
-            const test = new cgl.Function('test', [new cgl.ReturnStatement(new cgl.Reference(integerVar))], cgl.Kind.Int);
+            const test = new cgl.Function(
+                'test', [new cgl.ReturnStatement(new cgl.Reference(integerVar), cgl.Kind.Int)], cgl.Kind.Int
+            );
 
             expect(test.source()).to.equalIgnoreSpaces(`int test() {
                 return 0;

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -3,9 +3,15 @@ import * as cgl from '../src/calder';
 
 describe('Function', () => {
     describe('source', () => {
-        const glPosition = new cgl.InterfaceVariable(cgl.Qualifier.Out, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'gl_Position'));
-        const vertexPosition = new cgl.InterfaceVariable(cgl.Qualifier.Attribute, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'vertexPosition'));
-        const integerVar = new cgl.InterfaceVariable(cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), '0'));
+        const glPosition = new cgl.InterfaceVariable(
+            cgl.Qualifier.Out, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'gl_Position')
+        );
+        const vertexPosition = new cgl.InterfaceVariable(
+            cgl.Qualifier.Attribute, new cgl.VariableSource(new cgl.Type(cgl.Kind.Vec4), 'vertexPosition')
+        );
+        const integerVar = new cgl.InterfaceVariable(
+            cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), '0')
+        );
 
         it('creates the correct source', () => {
             const main = new cgl.Function('main', [
@@ -23,9 +29,7 @@ describe('Function', () => {
         });
 
         it('handles different return types', () => {
-            const test = new cgl.Function('test', [
-                new cgl.ReturnStatement(new cgl.Reference(integerVar)),
-            ], cgl.Kind.Int);
+            const test = new cgl.Function('test', [new cgl.ReturnStatement(new cgl.Reference(integerVar))], cgl.Kind.Int);
 
             expect(test.source()).to.equalIgnoreSpaces(`int test() {
                 return 0;


### PR DESCRIPTION
#3, #41

### Changes
- Adds ability to return different types in functions.
- Adds a `ReturnStatement` class for returning expressions.

### Usage


```js
// Declare reference
const zero = new cgl.Reference(
    new cgl.InterfaceVariable(
        cgl.Qualifier.In, new cgl.VariableSource(new cgl.Type(cgl.Kind.Int), '0')
    )
);

/**
 * int returnZero() {
 *   return 0;
 * }
 */
new cgl.Function('returnZero', [new cgl.ReturnStatement(zero)], cgl.Kind.Int);
```