### PR TITLE
Type helpers

### DIFF
--- a/src/expressions/math/infix/infix_expression.ts
+++ b/src/expressions/math/infix/infix_expression.ts
@@ -13,7 +13,9 @@ export default abstract class InfixExpression implements Expression {
         this.lhs = lhs;
         this.rhs = rhs;
 
-        if (!this.bothSameSizeVectors() && !this.bothSameSizeMatrices() && !this.bothSidesScalarTypes()) {
+        if (!this.lhs.returnType().checkVectorEquals(rhs.returnType()) &&
+            !this.lhs.returnType().checkMatrixEquals(rhs.returnType()) &&
+            !this.bothSidesScalarTypes()) {
             throw new TypeException('LHS and RHS must be of type Int, Float, or same size vector/matrix.');
         }
     }
@@ -25,50 +27,15 @@ export default abstract class InfixExpression implements Expression {
         return this.lhs.returnType();
     }
 
-    protected vectorType(value: Expression): boolean {
-        return value.returnType().checkEquals(new Type(Kind.Vec2))
-            || value.returnType().checkEquals(new Type(Kind.Vec3))
-            || value.returnType().checkEquals(new Type(Kind.Vec4))
-            || value.returnType().checkEquals(new Type(Kind.BVec2))
-            || value.returnType().checkEquals(new Type(Kind.BVec3))
-            || value.returnType().checkEquals(new Type(Kind.BVec4))
-            || value.returnType().checkEquals(new Type(Kind.IVec2))
-            || value.returnType().checkEquals(new Type(Kind.IVec3))
-            || value.returnType().checkEquals(new Type(Kind.IVec4));
-    }
-
-    protected matrixType(value: Expression): boolean {
-        return value.returnType().checkEquals(new Type(Kind.Mat2))
-            || value.returnType().checkEquals(new Type(Kind.Mat3))
-            || value.returnType().checkEquals(new Type(Kind.Mat4));
-    }
+    // Type Checking Helper Methods
 
     protected eitherSideVectorOrMatrix(lhs: Expression, rhs: Expression) {
-        return this.vectorType(lhs) || this.vectorType(rhs)
-            || this.matrixType(lhs) || this.matrixType(rhs);
-    }
-
-    protected bothSameSizeVectors(): boolean {
-        return (this.lhs.returnType().checkEquals(new Type(Kind.Vec2)) && this.rhs.returnType().checkEquals(new Type(Kind.Vec2)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.Vec3)) && this.rhs.returnType().checkEquals(new Type(Kind.Vec3)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.Vec4)) && this.rhs.returnType().checkEquals(new Type(Kind.Vec4)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.BVec2)) && this.rhs.returnType().checkEquals(new Type(Kind.BVec2)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.BVec3)) && this.rhs.returnType().checkEquals(new Type(Kind.BVec3)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.BVec4)) && this.rhs.returnType().checkEquals(new Type(Kind.BVec4)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.IVec2)) && this.rhs.returnType().checkEquals(new Type(Kind.IVec2)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.IVec3)) && this.rhs.returnType().checkEquals(new Type(Kind.IVec3)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.IVec4)) && this.rhs.returnType().checkEquals(new Type(Kind.IVec4)));
-    }
-
-    protected bothSameSizeMatrices(): boolean {
-        return (this.lhs.returnType().checkEquals(new Type(Kind.Mat2)) && this.rhs.returnType().checkEquals(new Type(Kind.Mat2)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.Mat3)) && this.rhs.returnType().checkEquals(new Type(Kind.Mat3)))
-            || (this.lhs.returnType().checkEquals(new Type(Kind.Mat4)) && this.rhs.returnType().checkEquals(new Type(Kind.Mat4)));
+        return this.lhs.returnType().isVectorType() || this.rhs.returnType().isVectorType()
+            || this.lhs.returnType().isMatrixType() || this.rhs.returnType().isMatrixType();
     }
 
     protected bothSidesScalarTypes(): boolean {
-        return (this.lhs.returnType().checkEquals(new Type(Kind.Int)) || this.lhs.returnType().checkEquals(new Type(Kind.Float)))
-            && (this.rhs.returnType().checkEquals(new Type(Kind.Int)) || this.rhs.returnType().checkEquals(new Type(Kind.Float)));
+        return (this.lhs.returnType().isScalarType()) && (this.rhs.returnType().isScalarType());
     }
 
     protected atLeastOneSideFloatType(): boolean {

--- a/src/expressions/math/infix/multiplication.ts
+++ b/src/expressions/math/infix/multiplication.ts
@@ -6,7 +6,7 @@ export default class Multiplication extends InfixExpression {
     constructor(lhs: Expression, rhs: Expression) {
         super(lhs, rhs);
 
-        if (!super.bothSameSizeMatrices() && super.eitherSideVectorOrMatrix(lhs, rhs)) {
+        if (!lhs.returnType().checkMatrixEquals(rhs.returnType()) && super.eitherSideVectorOrMatrix(lhs, rhs)) {
             throw new TypeException('LHS and RHS must be of type Int, Float, or both sides must be same size matrices.');
         }
     }

--- a/src/type.ts
+++ b/src/type.ts
@@ -51,21 +51,11 @@ export default class Type {
     }
 
     public checkVectorEquals(otherType: Type): boolean {
-        return (this.checkEquals(new Type(Kind.Vec2)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.Vec3)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.Vec4)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.BVec2)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.BVec3)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.BVec4)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.IVec2)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.IVec3)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.IVec4)) && this.checkEquals(otherType));
+        return this.isVectorType() && this.checkEquals(otherType);
     }
 
     public checkMatrixEquals(otherType: Type): boolean {
-        return (this.checkEquals(new Type(Kind.Mat2)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.Mat3)) && this.checkEquals(otherType))
-            || (this.checkEquals(new Type(Kind.Mat4)) && this.checkEquals(otherType));
+        return this.isMatrixType() && this.checkEquals(otherType);
     }
 
     // Type Checking Helper Methods

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,3 +1,4 @@
+import Kind from './kind';
 import MetaKind from './metakind';
 import TypeException from './exceptions/typeexception';
 
@@ -31,6 +32,8 @@ export default class Type {
         }
     }
 
+    // Equality Helper Methods
+
     public checkEquals(otherType: Type): boolean {
         // Note: for structs, this only verifies that they have the same structure (i.e. same # and types
         // of child types), but doesn't check that the variable names in the struct are identical.
@@ -45,5 +48,48 @@ export default class Type {
         }
 
         return true;
+    }
+
+    public checkVectorEquals(otherType: Type): boolean {
+        return (this.checkEquals(new Type(Kind.Vec2)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.Vec3)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.Vec4)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.BVec2)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.BVec3)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.BVec4)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.IVec2)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.IVec3)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.IVec4)) && this.checkEquals(otherType));
+    }
+
+    public checkMatrixEquals(otherType: Type): boolean {
+        return (this.checkEquals(new Type(Kind.Mat2)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.Mat3)) && this.checkEquals(otherType))
+            || (this.checkEquals(new Type(Kind.Mat4)) && this.checkEquals(otherType));
+    }
+
+    // Type Checking Helper Methods
+
+    public isScalarType(): boolean {
+        return this.checkEquals(new Type(Kind.Int))
+            || this.checkEquals(new Type(Kind.Float));
+    }
+
+    public isMatrixType(): boolean {
+        return this.checkEquals(new Type(Kind.Mat2))
+            || this.checkEquals(new Type(Kind.Mat3))
+            || this.checkEquals(new Type(Kind.Mat4));
+    }
+
+    public isVectorType(): boolean {
+        return this.checkEquals(new Type(Kind.Vec2))
+            || this.checkEquals(new Type(Kind.Vec3))
+            || this.checkEquals(new Type(Kind.Vec4))
+            || this.checkEquals(new Type(Kind.BVec2))
+            || this.checkEquals(new Type(Kind.BVec3))
+            || this.checkEquals(new Type(Kind.BVec4))
+            || this.checkEquals(new Type(Kind.IVec2))
+            || this.checkEquals(new Type(Kind.IVec3))
+            || this.checkEquals(new Type(Kind.IVec4));
     }
 }

--- a/src/variabledeclaration.ts
+++ b/src/variabledeclaration.ts
@@ -4,7 +4,7 @@ import Type from './type';
 
 export default class VariableDeclaration<V extends Variable> implements Expression {
     public readonly variable: V;
-    
+
     constructor(variable: V) {
         this.variable = variable;
     }


### PR DESCRIPTION
### Changes

Reduces coupling between `infix_expression.ts` module and type-specific checking by creating type helper methods in the `type.ts` module.