### PR TITLE
Remove `npm start` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ yarn install
 
 # Watch for changes to TypeScript, and build on change
 gulp watch
-
-# Run the compiled es5 JavaScript code
-npm start
 ```
 
 ### Testing


### PR DESCRIPTION
npm start isn’t a thing. We should not say it’s a thing in the README.