### PR TITLE
Use setter to buffer values with =, update demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 node_modules/
+.DS_Store

--- a/sample.html
+++ b/sample.html
@@ -1,4 +1,19 @@
 <html>
+  <head>
+    <style type="text/css">
+      html {
+        width: 100%;
+        height: 100%;
+      }
+      body {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    </style>
+  </head>
   <body>
     <canvas id="glCanvas" width="640" height="480"></canvas>
 

--- a/sample/index.js
+++ b/sample/index.js
@@ -55,19 +55,36 @@ mat4.perspective(projectionMatrix, fieldOfView, aspect, zNear, zFar);
 const modelViewMatrix = mat4.create();
 mat4.translate(modelViewMatrix, modelViewMatrix, [-0.0, 0.0, -6.0]);
 
-pipeline.useProgram();
-gl.clearColor(0.0, 0.0, 0.0, 1.0);
-gl.clearDepth(1.0);
-gl.enable(gl.DEPTH_TEST);
-gl.depthFunc(gl.LEQUAL);
-gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-pipeline.setAttribute('vertexPosition', [
-    1.0, 1.0, 0.0, 1.0,
-    -1.0, 1.0, 0.0, 1.0,
-    1.0, -1.0, 0.0, 1.0,
-    -1.0, -1.0, 0.0, 1.0
-]);
-pipeline.setUniform('colour', [1.0,  1.0,  1.0,  1.0]);
-pipeline.setUniform('modelView', modelViewMatrix);
-pipeline.setUniform('projection', projectionMatrix);
-pipeline.draw(4);
+function render() {
+    pipeline.useProgram();
+    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+    gl.clearDepth(1.0);
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LEQUAL);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    pipeline.vertexPosition = [
+        1.0, 1.0, 0.0, 1.0,
+        -1.0, 1.0, 0.0, 1.0,
+        1.0, -1.0, 0.0, 1.0,
+        -1.0, -1.0, 0.0, 1.0
+    ];
+    pipeline.colour = [1.0,  1.0,  1.0,  1.0];
+    pipeline.modelView = modelViewMatrix;
+    pipeline.projection = projectionMatrix;
+    pipeline.draw(4);
+}
+render();
+
+document.body.addEventListener('mousemove', function(e) {
+    const x = (e.clientX - window.innerWidth/2)/(window.innerWidth/2);
+    const y = (e.clientY - window.innerHeight/2)/(window.innerHeight/2);
+
+    mat4.identity(modelViewMatrix);
+    mat4.translate(modelViewMatrix, modelViewMatrix, [-0.0, 0.0, -6.0]);
+    mat4.rotate(modelViewMatrix, modelViewMatrix, y*Math.PI/3, [1, 0, 0]);
+    mat4.rotate(modelViewMatrix, modelViewMatrix, x*Math.PI/3, [0, 1, 0]);
+
+    if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(render);
+    }
+});

--- a/src/shaderpipeline.ts
+++ b/src/shaderpipeline.ts
@@ -6,11 +6,11 @@ import Shader from './shader';
 export default class ShaderPipeline {
     private readonly gl: WebGLRenderingContext;
     public program: WebGLProgram;
-    private attributePositions: Map<String, GLint>;
-    private attributeBuffers: Map<String, WebGLBuffer>;
-    private uniformPositions: Map<String, WebGLUniformLocation>;
-    private attributes: Map<String, InterfaceVariable>;
-    private uniforms: Map<String, InterfaceVariable>;
+    private attributePositions: Map<string, GLint>;
+    private attributeBuffers: Map<string, WebGLBuffer>;
+    private uniformPositions: Map<string, WebGLUniformLocation>;
+    private attributes: Map<string, InterfaceVariable>;
+    private uniforms: Map<string, InterfaceVariable>;
 
     constructor(gl: WebGLRenderingContext, vertexShader: Shader, fragmentShader: Shader) {
         this.gl = gl;
@@ -25,6 +25,13 @@ export default class ShaderPipeline {
         [...vertexShader.inputDecls, ...fragmentShader.inputDecls]
             .filter(input => input.variable.qualifier == Qualifier.Uniform)
             .forEach(input => this.uniforms.set(input.variable.name(), input.variable));
+
+        [...this.attributes.keys()].forEach(key => Object.defineProperty(this, key, {
+            set: (value: any[]) => this.setAttribute(key, value)
+        }));
+        [...this.uniforms.keys()].forEach(key => Object.defineProperty(this, key, {
+            set: (value: any[]) => this.setUniform(key, value)
+        }));
 
         this.compileProgram(vertexShader, fragmentShader);
         this.createBuffers();


### PR DESCRIPTION
Uses a js setter now so that you can use the `=` operator instead of `.setUniform` or `.setAttribute` on the shader pipeline object.

I also updated the demo so that the square rotates to "look" at your mouse.