### PR TITLE
Make geometry use classes, add comments

### DIFF
--- a/src/geometry/BakedGeometry.ts
+++ b/src/geometry/BakedGeometry.ts
@@ -1,5 +1,8 @@
 import { vec3 } from 'gl-matrix';
 
+/**
+ * After modelling is complete, a BakedGeometry should be returned for use in the renderer.
+ */
 export type BakedGeometry = {
     vertices: vec3[];
     normals: vec3[];

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -1,13 +1,41 @@
-import { vec3 } from 'gl-matrix';
+import { vec4 } from 'gl-matrix';
 
-export type Face = {
-    // The indices for the vertices representing the three points of this triangle/quad
-    indices: number[];
-    normal: vec3;
-};
+/**
+ * A representation of a surface on an object.
+ */
+export class Face {
+    /**
+     * References indices of vertices in a WorkingGeometry that make up a polygon. This polygon is
+     * the object's surface. This should be of length 3 for a triangle or 4 or a quad.
+     */
+    public indices: number[];
 
-export type WorkingGeometry = {
-    vertices: vec3[];
-    faces: Face[];
-    controlPoints: vec3[];
-};
+    /**
+     * A vector representing the direction out of the front of the face. The normal n should have
+     * n[3] = 1 to ensure that it is a vector in Affine space.
+     */
+    public normal: vec4;
+}
+
+/**
+ * A representation of geometry while modelling is happening.
+ */
+export class WorkingGeometry {
+    /**
+     * The points that make up the geometry, in no particular order. For each vertex v, v[3] must
+     * be equal to 0 to ensure that it is a point in Affine space rather than a vector.
+     */
+    public vertices: vec4[];
+
+    /**
+     * The surfaces of the object. Each face includes the indices of the vertices that make up the
+     * surface's polygon.
+     */
+    public faces: Face[];
+
+    /**
+     * A set of points to snap to or reference when combining geometries. For each point p, p[3]
+     * must be equal to 0 to ensure that it is a point in Affine space.
+     */
+    public controlPoints: vec4[];
+}


### PR DESCRIPTION
Unfortunately when we use `vec4`, we can't rely on the type system to verify that points have a 0 and vectors have a 1 as their last value, so this is specified in comments. Users should specify `vec3`s in actual interfaces to these objects, ideally, and we just trust ourselves to construct the proper `vec4` for internal use.