### PR TITLE
Initial armature code. Added `Node` and `GeometryNode` classes.

### DIFF
--- a/src/armature/GeometryNode.ts
+++ b/src/armature/GeometryNode.ts
@@ -1,0 +1,24 @@
+import { flatMap } from 'lodash';
+import { mat4 } from 'gl-matrix';
+import { BakedGeometry } from '../geometry/BakedGeometry';
+import { RenderObject } from '../renderer/interfaces/RenderObject';
+import { Node } from './Node';
+
+export class GeometryNode extends Node {
+    public readonly geometry: BakedGeometry;
+
+    constructor(geometry: BakedGeometry, children: Node[] = []) {
+        super(children);
+        this.geometry = geometry;
+    }
+
+    public traverse(coordinateSpace: mat4 = mat4.create()): RenderObject[] {
+        const matrix = this.transformation.getTransformation();
+        mat4.multiply(matrix, coordinateSpace, matrix);
+
+        return [
+            { ...this.geometry, transform: matrix },
+            ...flatMap(this.children, (c: Node) => c.traverse(matrix))
+        ];
+    }
+}

--- a/src/armature/GeometryNode.ts
+++ b/src/armature/GeometryNode.ts
@@ -12,6 +12,13 @@ export class GeometryNode extends Node {
         this.geometry = geometry;
     }
 
+    /**
+     * Returns an array of `RenderObject`s denoting `GeometryNode`s
+     * transformations multiplied by the `coordinateSpace` parameter.
+     *
+     * @param {mat4} coordinateSpace
+     * @returns {RenderObject[]}
+     */
     public traverse(coordinateSpace: mat4 = mat4.create()): RenderObject[] {
         const matrix = this.transformation.getTransformation();
         mat4.multiply(matrix, coordinateSpace, matrix);

--- a/src/armature/GeometryNode.ts
+++ b/src/armature/GeometryNode.ts
@@ -1,12 +1,21 @@
-import { flatMap } from 'lodash';
 import { mat4 } from 'gl-matrix';
+import { flatMap } from 'lodash';
 import { BakedGeometry } from '../geometry/BakedGeometry';
 import { RenderObject } from '../renderer/interfaces/RenderObject';
 import { Node } from './Node';
 
+/**
+ * A derived `Node` with an additional `geometry` property.
+ */
 export class GeometryNode extends Node {
     public readonly geometry: BakedGeometry;
 
+    /**
+     * Instantiates a new `GeometryNode`.
+     *
+     * @param {BakedGeometry} geometry
+     * @param {Node[]} children
+     */
     constructor(geometry: BakedGeometry, children: Node[] = []) {
         super(children);
         this.geometry = geometry;

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -11,12 +11,17 @@ export class Node {
         this.children = children;
     }
 
+    /**
+     * Gets the node's rotation.
+     *
+     * @returns {vec3}
+     */
     public getRotation(): vec3 {
         return this.transformation.rotation;
     }
 
     /**
-     * Sets the rotation for a particular node by overriding the private `transformation` property.
+     * Sets the rotation for the node by updating the private `transformation` property.
      *
      * @param {vec3} rotation
      */
@@ -24,22 +29,50 @@ export class Node {
         this.transformation.rotation = rotation;
     }
 
+    /**
+     * Gets the node's scale.
+     *
+     * @returns {vec3}
+     */
     public getScale(): vec3 {
         return this.transformation.scale;
     }
 
+    /**
+     * Sets the scale for the node by updating the private `transformation` property.
+     *
+     * @param {vec3} scale
+     */
     public setScale(scale: vec3) {
         this.transformation.scale = scale;
     }
 
+    /**
+     * Gets the node's position.
+     *
+     * @returns {vec3}
+     */
     public getPosition(): vec3 {
         return this.transformation.position;
     }
 
-    public setPosition(translation: vec3) {
-        this.transformation.position = translation;
+    /**
+     * Sets the position for the node by updating the private `transformation`
+     * property.
+     *
+     * @param {vec3} position
+     */
+    public setPosition(position: vec3) {
+        this.transformation.position = position;
     }
 
+    /**
+     * Returns an array of `RenderObject`s denoting `GeometryNode`s
+     * transformations multiplied by the `coordinateSpace` parameter.
+     *
+     * @param {mat4} coordinateSpace
+     * @returns {RenderObject[]}
+     */
     public traverse(coordinateSpace: mat4 = mat4.create()): RenderObject[] {
         const matrix = this.transformation.getTransformation();
         mat4.multiply(matrix, coordinateSpace, matrix);

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -1,0 +1,49 @@
+import { flatMap } from 'lodash';
+import { mat4, vec3 } from 'gl-matrix';
+import { RenderObject } from '../renderer/interfaces/RenderObject';
+import { Transformation } from './Transformation';
+
+export class Node {
+    public readonly children: Node[];
+    protected transformation: Transformation = new Transformation();
+
+    constructor(children: Node[] = []) {
+        this.children = children;
+    }
+
+    public getRotation(): vec3 {
+        return this.transformation.rotation;
+    }
+
+    /**
+     * Sets the rotation for a particular node by overriding the private `transformation` property.
+     *
+     * @param {vec3} rotation
+     */
+    public setRotation(rotation: vec3) {
+        this.transformation.rotation = rotation;
+    }
+
+    public getScale(): vec3 {
+        return this.transformation.scale;
+    }
+
+    public setScale(scale: vec3) {
+        this.transformation.scale = scale;
+    }
+
+    public getPosition(): vec3 {
+        return this.transformation.position;
+    }
+
+    public setPosition(translation: vec3) {
+        this.transformation.position = translation;
+    }
+
+    public traverse(coordinateSpace: mat4 = mat4.create()): RenderObject[] {
+        const matrix = this.transformation.getTransformation();
+        mat4.multiply(matrix, coordinateSpace, matrix);
+
+        return flatMap(this.children, (c: Node) => c.traverse(matrix));
+    }
+}

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -1,12 +1,20 @@
-import { flatMap } from 'lodash';
 import { mat4, vec3 } from 'gl-matrix';
+import { flatMap } from 'lodash';
 import { RenderObject } from '../renderer/interfaces/RenderObject';
 import { Transformation } from './Transformation';
 
+/**
+ * A `Node` in a scene-graph.
+ */
 export class Node {
     public readonly children: Node[];
     protected transformation: Transformation = new Transformation();
 
+    /**
+     * Instantiates a new `Node`.
+     *
+     * @param {Node[]} children
+     */
     constructor(children: Node[] = []) {
         this.children = children;
     }

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -8,6 +8,12 @@ export class Transformation {
     public rotation: vec3 = vec3.fromValues(0, 0, 0);
     public scale: vec3 = vec3.fromValues(1, 1, 1);
 
+    /**
+     * Returns a matrix representation of the transformation this object
+     * represents.
+     *
+     * @returns {mat4}
+     */
     public getTransformation(): mat4 {
         const matrix = mat4.fromScaling(mat4.create(), this.scale);
 

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -1,0 +1,21 @@
+import { mat4, vec3 } from 'gl-matrix';
+
+/**
+ * Not intended to be user facing.
+ */
+export class Transformation {
+    public position: vec3 = vec3.fromValues(0, 0, 0);
+    public rotation: vec3 = vec3.fromValues(0, 0, 0);
+    public scale: vec3 = vec3.fromValues(1, 1, 1);
+
+    public getTransformation(): mat4 {
+        const matrix = mat4.fromScaling(mat4.create(), this.scale);
+
+        mat4.rotateX(matrix, matrix, this.rotation[0]);
+        mat4.rotateY(matrix, matrix, this.rotation[1]);
+        mat4.rotateZ(matrix, matrix, this.rotation[2]);
+        mat4.translate(matrix, matrix, this.position);
+
+        return matrix;
+    }
+}

--- a/src/geometry/BakedGeometry.ts
+++ b/src/geometry/BakedGeometry.ts
@@ -4,4 +4,5 @@ export type BakedGeometry = {
     vertices: vec3[];
     normals: vec3[];
     indices: number[];
+    colors: vec3[];
 };

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -2,6 +2,7 @@ import { Camera } from './Camera';
 import { drawAxes, DrawAxesProps } from './commands/drawAxes';
 import { drawObject, DrawObjectProps } from './commands/drawObject';
 import { Light } from './interfaces/Light';
+import { RenderObject } from './interfaces/RenderObject';
 
 import { mat4, vec4 } from 'gl-matrix';
 
@@ -9,17 +10,6 @@ import { mat4, vec4 } from 'gl-matrix';
 import REGL = require('regl');
 
 // tslint:disable:no-unsafe-any
-
-/*
- * A collection of the properties needed to render something using the default shader
- */
-export interface RenderObject {
-    transform: REGL.Mat4;
-    vertices: REGL.Vec3[];
-    normals: REGL.Vec3[];
-    colors: REGL.Vec3[];
-    indices: number[];
-}
 
 /**
  * Manages all scene information and is responsible for rendering it to the screen

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -1,8 +1,8 @@
-import { Camera } from './Camera';
 import { drawAxes, DrawAxesProps } from './commands/drawAxes';
 import { drawObject, DrawObjectProps } from './commands/drawObject';
 import { Light } from './interfaces/Light';
 import { RenderObject } from './interfaces/RenderObject';
+import { Camera } from './Camera';
 
 import { mat4, vec4 } from 'gl-matrix';
 

--- a/src/renderer/interfaces/RenderObject.ts
+++ b/src/renderer/interfaces/RenderObject.ts
@@ -1,0 +1,7 @@
+import { mat4 } from 'gl-matrix';
+import { BakedGeometry } from '../../geometry/BakedGeometry';
+
+/*
+ * A collection of the properties needed to render something using the default shader
+ */
+export type RenderObject = BakedGeometry & { transform: mat4 };

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -1,0 +1,30 @@
+import { vec3, vec4 } from 'gl-matrix';
+import { BakedGeometry } from '../../src/geometry/BakedGeometry';
+import { GeometryNode } from '../../src/armature/GeometryNode';
+import { Node } from '../../src/armature/Node';
+import { RenderObject } from '../../src/renderer/interfaces/RenderObject';
+import '../glMatrix';
+
+describe('Node', () => {
+    describe('traverse', () => {
+        it('traverses and return an array of `RenderObject`', () => {
+            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometryChild = new GeometryNode(geometry);
+            const nodeChild = new Node([geometryChild]);
+            const root = new Node([nodeChild]);
+
+            root.setPosition(vec3.fromValues(1, 0, 0));
+            nodeChild.setRotation(vec3.fromValues(Math.PI / 2, 0, 0));
+
+            const inputPoint = vec4.fromValues(0, 1, 0, 1);
+            const expectedPoint = vec4.fromValues(1, 0, 1, 1);
+            const renderObjects: RenderObject[] = root.traverse();
+
+            expect(renderObjects.length).toBe(1);
+
+            const transformedPoint = vec4.create();
+            vec4.transformMat4(transformedPoint, inputPoint, renderObjects[0].transform);
+            expect(transformedPoint).toEqualVec4(expectedPoint);
+        });
+    });
+});

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -1,7 +1,7 @@
 import { vec3, vec4 } from 'gl-matrix';
-import { BakedGeometry } from '../../src/geometry/BakedGeometry';
 import { GeometryNode } from '../../src/armature/GeometryNode';
 import { Node } from '../../src/armature/Node';
+import { BakedGeometry } from '../../src/geometry/BakedGeometry';
 import { RenderObject } from '../../src/renderer/interfaces/RenderObject';
 import '../glMatrix';
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -7,7 +7,7 @@ import '../glMatrix';
 
 describe('Node', () => {
     describe('traverse', () => {
-        it('flattens the parent\'s coordinate space and returns an array of `RenderObject`s', () => {
+        it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
             const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -7,17 +7,57 @@ import '../glMatrix';
 
 describe('Node', () => {
     describe('traverse', () => {
-        it('traverses and return an array of `RenderObject`', () => {
+        it('flattens the parent\'s coordinate space and returns an array of `RenderObject`s', () => {
             const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
 
+            // Translate the root node 1 unit in the x-direction.
             root.setPosition(vec3.fromValues(1, 0, 0));
+
+            // Rotate this child matrix 90 degrees about the x-axis.
             nodeChild.setRotation(vec3.fromValues(Math.PI / 2, 0, 0));
 
+            /**
+             * Here we're defining a test point and what we expect the result of
+             * the transformation on that point should be, so that we can assert
+             * that applying the returned transformation yields the expected
+             * result.
+             *
+             * Because it does a translation, and then a rotation, we expect the
+             * point that was at 0, 1, 0 should now be at 1, 0, 1.
+             */
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(1, 0, 1, 1);
+
+            const renderObjects: RenderObject[] = root.traverse();
+
+            expect(renderObjects.length).toBe(1);
+
+            const transformedPoint = vec4.create();
+            vec4.transformMat4(transformedPoint, inputPoint, renderObjects[0].transform);
+            expect(transformedPoint).toEqualVec4(expectedPoint);
+        });
+
+        it('defaults to no transformation', () => {
+            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometryChild = new GeometryNode(geometry);
+            const nodeChild = new Node([geometryChild]);
+            const root = new Node([nodeChild]);
+
+            /**
+             * Here we're defining a test point and what we expect the result of
+             * the transformation on that point should be, so that we can assert
+             * that applying the returned transformation yields the expected
+             * result.
+             *
+             * Because there are no transformations, we expect the point that
+             * was at 0, 1, 0 should still be at 0, 1, 0.
+             */
+            const inputPoint = vec4.fromValues(0, 1, 0, 1);
+            const expectedPoint = vec4.fromValues(0, 1, 0, 1);
+
             const renderObjects: RenderObject[] = root.traverse();
 
             expect(renderObjects.length).toBe(1);

--- a/tests/glMatrix.ts
+++ b/tests/glMatrix.ts
@@ -1,10 +1,11 @@
-import { mat4, quat, vec3 } from 'gl-matrix';
+import { mat4, quat, vec3, vec4 } from 'gl-matrix';
 
 declare global {
     namespace jest {
         interface Matchers<R> {
             toEqualMat4(argument: mat4): { pass: boolean; message(): string };
             toEqualVec3(argument: vec3): { pass: boolean; message(): string };
+            toEqualVec4(argument: vec4): { pass: boolean; message(): string };
             toEqualQuat(argument: quat): { pass: boolean; message(): string };
         }
     }
@@ -37,6 +38,21 @@ expect.extend({
             return {
                 message: () =>
                     `expected ${vec3.str(received)} to be equal to ${vec3.str(argument)}`,
+                pass: false
+            };
+        }
+    },
+    toEqualVec4(received: vec4, argument: vec4) {
+        if (vec4.equals(received, argument)) {
+            return {
+                message: () =>
+                    `expected ${vec4.str(received)} to not be equal to ${vec4.str(argument)}`,
+                pass: true
+            };
+        } else {
+            return {
+                message: () =>
+                    `expected ${vec4.str(received)} to be equal to ${vec4.str(argument)}`,
                 pass: false
             };
         }

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,13 @@
     "tslint-config-prettier"
   ],
   "rules": {
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "lowercase-first",
+        "named-imports-order": "lowercase-first"
+      }
+    ],
     "mocha-no-side-effect-code": false,
     "missing-jsdoc": false,
     "no-relative-imports": false,


### PR DESCRIPTION
### Changes
- Closes #29 
- Adds `Node` and `GeometryNode` armature classes
- Adds specs for `Node`'s `traverse` method