### PR TITLE
Visually debug armature with bones

### DIFF
--- a/src/armature/GeometryNode.ts
+++ b/src/armature/GeometryNode.ts
@@ -28,13 +28,22 @@ export class GeometryNode extends Node {
      * @param {mat4} coordinateSpace
      * @returns {RenderObject[]}
      */
-    public traverse(coordinateSpace: mat4 = mat4.create()): RenderObject[] {
+    public traverse(
+        coordinateSpace: mat4 = mat4.create(),
+        makeBones: boolean = false
+    ): RenderObject[] {
         const matrix = this.transformation.getTransformation();
         mat4.multiply(matrix, coordinateSpace, matrix);
 
-        return [
+        const renderObjects: RenderObject[] = [
             { ...this.geometry, transform: matrix },
-            ...flatMap(this.children, (c: Node) => c.traverse(matrix))
+            ...flatMap(this.children, (c: Node) => c.traverse(matrix, makeBones))
         ];
+
+        if (makeBones) {
+            this.appendBoneRenderObject(coordinateSpace, renderObjects);
+        }
+
+        return renderObjects;
     }
 }

--- a/src/armature/NodeRenderObject.ts
+++ b/src/armature/NodeRenderObject.ts
@@ -1,6 +1,6 @@
 import { RenderObject } from '../renderer/interfaces/RenderObject';
 
 export type NodeRenderObject = {
-    renderObjects: RenderObject[];
+    geometry: RenderObject[];
     bones: RenderObject[];
 };

--- a/src/armature/NodeRenderObject.ts
+++ b/src/armature/NodeRenderObject.ts
@@ -1,0 +1,6 @@
+import { RenderObject } from '../renderer/interfaces/RenderObject';
+
+export type NodeRenderObject = {
+    renderObjects: RenderObject[];
+    bones: RenderObject[];
+};

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -4,9 +4,19 @@ import { mat4, vec3 } from 'gl-matrix';
  * Not intended to be user facing.
  */
 export class Transformation {
-    public position: vec3 = vec3.fromValues(0, 0, 0);
-    public rotation: vec3 = vec3.fromValues(0, 0, 0);
-    public scale: vec3 = vec3.fromValues(1, 1, 1);
+    public position: vec3;
+    public rotation: vec3;
+    public scale: vec3;
+
+    constructor(
+        position: vec3 = vec3.fromValues(0, 0, 0),
+        rotation: vec3 = vec3.fromValues(0, 0, 0),
+        scale: vec3 = vec3.fromValues(1, 1, 1)
+    ) {
+        this.position = position;
+        this.rotation = rotation;
+        this.scale = scale;
+    }
 
     /**
      * Returns a matrix representation of the transformation this object

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -25,12 +25,13 @@ export class Transformation {
      * @returns {mat4}
      */
     public getTransformation(): mat4 {
-        const matrix = mat4.fromScaling(mat4.create(), this.scale);
+        const matrix = mat4.create();
 
+        mat4.translate(matrix, matrix, this.position);
         mat4.rotateX(matrix, matrix, this.rotation[0]);
         mat4.rotateY(matrix, matrix, this.rotation[1]);
         mat4.rotateZ(matrix, matrix, this.rotation[2]);
-        mat4.translate(matrix, matrix, this.position);
+        mat4.scale(matrix, matrix, this.scale);
 
         return matrix;
     }

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -58,7 +58,7 @@ renderer.camera.lookAt(vec3.fromValues(2, 0, -4));
 
 // Create the armature
 const geometryNode = new GeometryNode({ vertices, normals, indices, colors });
-geometryNode.setPosition(vec3.fromValues(0, 1, 0));
+geometryNode.setPosition(vec3.fromValues(1, 1, 0));
 
 const parentNode = new Node([geometryNode]);
 parentNode.setPosition(vec3.fromValues(0, 1, 0));

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -4,6 +4,7 @@ import { Renderer } from '../renderer/Renderer';
 import { vec3 } from 'gl-matrix';
 import { range } from 'lodash';
 import { GeometryNode } from '../armature/GeometryNode';
+import { Node } from '../armature/Node';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
 const light2: Light = { lightPosition: [700, 500, 50], lightColor: [3, 3, 3], lightIntensity: 100 };
@@ -14,7 +15,6 @@ const renderer: Renderer = new Renderer(800, 600, 2);
 renderer.addLight(light1);
 renderer.addLight(light2);
 
-const transform = vec3.fromValues(0, 0, -4);
 const vertices: vec3[] = [];
 const normals: vec3[] = [];
 const indices: number[] = [];
@@ -53,12 +53,15 @@ colors.push(...vertices.map(() => vec3.fromValues(1, 0, 0)));
 
 document.body.appendChild(renderer.stage);
 
-renderer.camera.moveTo(vec3.fromValues(0, 0, 4));
+renderer.camera.moveTo(vec3.fromValues(0, 0, 8));
 renderer.camera.lookAt(vec3.fromValues(2, 0, -4));
 
 // Create the armature
 const geometryNode = new GeometryNode({ vertices, normals, indices, colors });
-geometryNode.setPosition(transform);
+geometryNode.setPosition(vec3.fromValues(0, 1, 0));
+
+const parentNode = new Node([geometryNode]);
+parentNode.setPosition(vec3.fromValues(0, 1, 0));
 
 // Draw the armature
-renderer.draw([geometryNode], true);
+renderer.draw([parentNode], { drawAxes: true, drawArmatureBones: true });

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -92,29 +92,33 @@ export class Renderer {
         this.drawAxes = createDrawAxes(regl);
     }
 
-    public draw(objects: Node[], debug: DebugParams = {}) {
+    public draw(
+        objects: Node[],
+        debug: DebugParams = { drawAxes: false, drawArmatureBones: false }
+    ) {
         this.clearAll();
 
         this.drawObject(
-            flatMap(objects, (n: Node) => n.traverse(mat4.create(), debug.drawArmatureBones)).map(
-                (o: RenderObject) => {
-                    return {
-                        model: o.transform,
-                        cameraTransform: this.camera.getTransform(),
-                        projectionMatrix: this.projectionMatrix,
-                        positions: o.vertices,
-                        normals: o.normals,
-                        colors: o.colors,
-                        indices: o.indices,
-                        isShadeless: !!o.isShadeless,
-                        numLights: this.lights.length,
-                        lights: this.lights
-                    };
-                }
-            )
+            flatMap(
+                objects,
+                (n: Node) => n.traverse(mat4.create(), debug.drawArmatureBones).renderObjects
+            ).map((o: RenderObject) => {
+                return {
+                    model: o.transform,
+                    cameraTransform: this.camera.getTransform(),
+                    projectionMatrix: this.projectionMatrix,
+                    positions: o.vertices,
+                    normals: o.normals,
+                    colors: o.colors,
+                    indices: o.indices,
+                    isShadeless: !!o.isShadeless,
+                    numLights: this.lights.length,
+                    lights: this.lights
+                };
+            })
         );
 
-        if (debug) {
+        if (debug.drawAxes) {
             this.drawCrosshairs();
         }
     }

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -100,7 +100,11 @@ export class Renderer {
 
         const renderObjects = objects.reduce(
             (accum: NodeRenderObject, node: Node) => {
-                const childObjects = node.traverse(mat4.create(), true, debug.drawArmatureBones === true);
+                const childObjects = node.traverse(
+                    mat4.create(),
+                    true,
+                    debug.drawArmatureBones === true
+                );
                 accum.geometry.push(...childObjects.geometry);
                 accum.bones.push(...childObjects.bones);
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -10,6 +10,7 @@ import { mat4, vec4 } from 'gl-matrix';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
 import { Node } from '../armature/Node';
+import { DebugParams } from './interfaces/DebugParams';
 
 // tslint:disable:no-unsafe-any
 
@@ -91,23 +92,26 @@ export class Renderer {
         this.drawAxes = createDrawAxes(regl);
     }
 
-    public draw(objects: Node[], debug: boolean = false) {
+    public draw(objects: Node[], debug: DebugParams = {}) {
         this.clearAll();
 
         this.drawObject(
-            flatMap(objects, (n: Node) => n.traverse()).map((o: RenderObject) => {
-                return {
-                    model: o.transform,
-                    cameraTransform: this.camera.getTransform(),
-                    projectionMatrix: this.projectionMatrix,
-                    positions: o.vertices,
-                    normals: o.normals,
-                    colors: o.colors,
-                    indices: o.indices,
-                    numLights: this.lights.length,
-                    lights: this.lights
-                };
-            })
+            flatMap(objects, (n: Node) => n.traverse(mat4.create(), debug.drawArmatureBones)).map(
+                (o: RenderObject) => {
+                    return {
+                        model: o.transform,
+                        cameraTransform: this.camera.getTransform(),
+                        projectionMatrix: this.projectionMatrix,
+                        positions: o.vertices,
+                        normals: o.normals,
+                        colors: o.colors,
+                        indices: o.indices,
+                        isShadeless: !!o.isShadeless,
+                        numLights: this.lights.length,
+                        lights: this.lights
+                    };
+                }
+            )
         );
 
         if (debug) {

--- a/src/renderer/commands/createDrawObject.ts
+++ b/src/renderer/commands/createDrawObject.ts
@@ -14,7 +14,7 @@ interface Uniforms {
     lightPositions: REGL.Vec3[];
     lightColors: REGL.Vec3[];
     lightIntensities: number[];
-    inShaded: boolean;
+    isShadeless: boolean;
 }
 
 interface Attributes {
@@ -34,7 +34,7 @@ export interface DrawObjectProps {
     normals: REGL.Vec3[];
     colors: REGL.Vec3[];
     indices: number[];
-    inShaded: boolean;
+    isShadeless: boolean;
 }
 
 /**

--- a/src/renderer/commands/createDrawObject.ts
+++ b/src/renderer/commands/createDrawObject.ts
@@ -14,6 +14,7 @@ interface Uniforms {
     lightPositions: REGL.Vec3[];
     lightColors: REGL.Vec3[];
     lightIntensities: number[];
+    inShaded: boolean;
 }
 
 interface Attributes {
@@ -33,6 +34,7 @@ export interface DrawObjectProps {
     normals: REGL.Vec3[];
     colors: REGL.Vec3[];
     indices: number[];
+    inShaded: boolean;
 }
 
 /**
@@ -81,27 +83,34 @@ export function createDrawObject(
             uniform vec3 lightPositions[MAX_LIGHTS];
             uniform vec3 lightColors[MAX_LIGHTS];
             uniform float lightIntensities[MAX_LIGHTS];
+            uniform bool isShadeless;
 
             void main() {
                 vec3 normal = normalize(vertexNormal);
                 vec3 color = vec3(0.0, 0.0, 0.0);
 
-                for (int i = 0; i < MAX_LIGHTS; i++) {
-                    if (i >= numLights) break;
+                if (isShadeless) {
+                    color = vertexColor;
+                } else {
+                    // Use the renderer lights in the shader
+                    for (int i = 0; i < MAX_LIGHTS; i++) {
+                        if (i >= numLights) break;
 
-                    vec3 lightPosition = (view * vec4(lightPositions[i], 1.0)).xyz;
-                    vec3 lightDir = normalize(lightPosition - vertexPosition);
-                    float lambertian = max(dot(lightDir, normal), 0.0);
+                        vec3 lightPosition = (view * vec4(lightPositions[i], 1.0)).xyz;
+                        vec3 lightDir = normalize(lightPosition - vertexPosition);
+                        float lambertian = max(dot(lightDir, normal), 0.0);
 
-                    color += lambertian * vertexColor;
+                        color += lambertian * vertexColor;
 
-                    vec3 viewDir = normalize(-vertexPosition);
-                    float spec = pow(
-                        max(dot(viewDir, reflect(-lightDir, normal)), 0.0),
-                        lightIntensities[i]);
+                        vec3 viewDir = normalize(-vertexPosition);
+                        float spec = pow(
+                            max(dot(viewDir, reflect(-lightDir, normal)), 0.0),
+                            lightIntensities[i]);
 
-                    color += spec * lightColors[i];
+                        color += spec * lightColors[i];
+                    }
                 }
+
                 gl_FragColor = vec4(color, 1.0);
             }
         `,
@@ -115,6 +124,7 @@ export function createDrawObject(
             view: regl.prop('cameraTransform'),
             model: regl.prop('model'),
             numLights: regl.prop('numLights'),
+            isShadeless: regl.prop('isShadeless'),
             ...buildLightMetadata(maxLights)
         },
         elements: regl.prop('indices')

--- a/src/renderer/interfaces/DebugParams.ts
+++ b/src/renderer/interfaces/DebugParams.ts
@@ -1,0 +1,17 @@
+/*
+ * A collection of behaviours in Renderer that enable easier visual debugging of
+ * geometry and armatures.
+ */
+export type DebugParams = {
+    /**
+     * Draws the cross-hairs for the axes in the bottom left-hand corner of the
+     * screen.
+     */
+    drawAxes?: boolean;
+
+    /**
+     * Draw a shape representing the relation of a `Node` to its parent, on top
+     * of the rest of the image so it's visible.
+     */
+    drawArmatureBones?: boolean;
+};

--- a/src/renderer/interfaces/RenderObject.ts
+++ b/src/renderer/interfaces/RenderObject.ts
@@ -2,6 +2,16 @@ import { mat4 } from 'gl-matrix';
 import { BakedGeometry } from '../../geometry/BakedGeometry';
 
 /*
- * A collection of the properties needed to render something using the default shader
+ * A collection of the properties needed to render something using the default
+ * shader.
  */
-export type RenderObject = BakedGeometry & { transform: mat4 };
+export type RenderObject = BakedGeometry & {
+    transform: mat4;
+
+    /**
+     * Optional type denoting if the object is shaded. If this is present AND
+     * `true`, then we will shade this object using the lights in the
+     * `Renderer`.
+     */
+    isShadeless?: boolean;
+};

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -31,7 +31,7 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(1, 0, 1, 1);
 
-            const renderObjects: RenderObject[] = root.traverse();
+            const renderObjects: RenderObject[] = root.traverse().renderObjects;
 
             expect(renderObjects.length).toBe(1);
 
@@ -58,7 +58,7 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(0, 1, 0, 1);
 
-            const renderObjects: RenderObject[] = root.traverse();
+            const renderObjects: RenderObject[] = root.traverse().renderObjects;
 
             expect(renderObjects.length).toBe(1);
 


### PR DESCRIPTION
There is now a debug option to draw bones of an armature. Bones are drawn without shading, on top of everything else so that they are always visible, from the parent's origin to the current node's origin.

Here is an example (the sphere is attached with its center at the tip of the bone):
![screen shot 2018-05-11 at 7 37 13 am](https://user-images.githubusercontent.com/5315059/39922719-5a762712-54ee-11e8-9edb-642fc0ca5a51.png)
