### PR TITLE
Calculate face normals upon baking based on faces

### DIFF
--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -93,8 +93,8 @@ export class WorkingGeometry {
             const p1: vec4 = this.vertices[face.indices[0]];
             const p2: vec4 = this.vertices[face.indices[1]];
             const p3: vec4 = this.vertices[face.indices[2]];
-            const v1: vec3 = Affine.truncate(vec4.subtract(vec4.create(), p1, p2));
-            const v2: vec3 = Affine.truncate(vec4.subtract(vec4.create(), p2, p3));
+            const v1: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p1, p2));
+            const v2: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p2, p3));
 
             return vec3.cross(vec3.create(), v1, v2);
         });

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -13,20 +13,13 @@ export class Face {
     public indices: number[];
 
     /**
-     * A vector representing the direction out of the front of the face. The normal n should have
-     * n[3] = 1 to ensure that it is a vector in Affine space.
-     */
-    public normal: vec4;
-
-    /**
      * @param {number[]} indices: Reference indeces of vertices in a WorkingGeometry.
      * @param {vec4} normal: A fector representing the direction out of the face.
      * @return {Face}
      */
-    constructor(indices: number[], normal: vec3) {
+    constructor(indices: number[]) {
         // TODO(pbardea): Verify length of indices here.
         this.indices = indices;
-        this.normal = Affine.createVector(normal);
     }
 }
 
@@ -97,7 +90,13 @@ export class WorkingGeometry {
             return accum.concat(face.indices);
         }, []);
         const bakedNormals = this.faces.map((face: Face) => {
-            return vec3.fromValues(face.normal[0], face.normal[1], face.normal[2]);
+            const p1: vec4 = this.vertices[face.indices[0]];
+            const p2: vec4 = this.vertices[face.indices[1]];
+            const p3: vec4 = this.vertices[face.indices[2]];
+            const v1: vec3 = Affine.truncate(vec4.subtract(vec4.create(), p1, p2));
+            const v2: vec3 = Affine.truncate(vec4.subtract(vec4.create(), p2, p3));
+
+            return vec3.cross(vec3.create(), v1, v2);
         });
 
         // Make all of the baked shapes red for now

--- a/src/utils/affine.ts
+++ b/src/utils/affine.ts
@@ -21,4 +21,13 @@ export namespace Affine {
     export function createVector(vector: vec3): vec4 {
         return vec4.fromValues(vector[0], vector[1], vector[2], 0);
     }
+
+    /**
+     * Convert a vector from Affine space to 3D space.
+     * @param {vec4} vector: The vector to truncate.
+     * @return {vec3}: The vector without the last element.
+     */
+    export function truncate(vector: vec4): vec3 {
+        return vec3.fromValues(vector[0], vector[1], vector[2]);
+    }
 }

--- a/src/utils/affine.ts
+++ b/src/utils/affine.ts
@@ -27,7 +27,7 @@ export namespace Affine {
      * @param {vec4} vector: The vector to truncate.
      * @return {vec3}: The vector without the last element.
      */
-    export function truncate(vector: vec4): vec3 {
+    export function to3D(vector: vec4): vec3 {
         return vec3.fromValues(vector[0], vector[1], vector[2]);
     }
 }

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -10,13 +10,10 @@ describe('Face', () => {
     describe('constructor', () => {
         it('can create an object as specified', () => {
             const indices = [0, 1, 2];
-            const n = [0, 1, 2];
-            const normalVec3 = vec3.fromValues(n[0], n[1], n[2]);
 
-            const face = new Face(indices, normalVec3);
+            const face = new Face(indices);
 
             expect(face.indices).toEqual(indices);
-            expect(face.normal).toEqualVec4(vec4.fromValues(n[0], n[1], n[2], 0));
         });
     });
 });
@@ -37,8 +34,7 @@ describe('WorkingGeometry', () => {
                 vec3.fromValues(1, 1, 0),
                 vec3.fromValues(1, 0, 0)
             ];
-            const normal = vec3.fromValues(0, 0, 1);
-            const faces = [new Face([0, 1, 2], normal), new Face([0, 2, 3], normal)];
+            const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
             const geo = new WorkingGeometry(vertices, faces, controlPoints);
 
@@ -60,8 +56,7 @@ describe('WorkingGeometry', () => {
                 vec3.fromValues(1, 1, 0),
                 vec3.fromValues(1, 0, 0)
             ];
-            const normal = vec3.fromValues(0, 0, 1);
-            const faces = [new Face([0, 1, 2], normal), new Face([0, 2, 3], normal)];
+            const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
             const square = new WorkingGeometry(vertices, faces, controlPoints);
             const bakedSquare = square.bake();
@@ -69,7 +64,10 @@ describe('WorkingGeometry', () => {
             // Not testing the colors yet since they don't do anything useful
             expect(bakedSquare.indices).toEqual([0, 1, 2, 0, 2, 3]);
             expect(bakedSquare.vertices).toEqual(vertices);
-            expect(bakedSquare.normals).toEqual([normal, normal]);
+            expect(bakedSquare.normals).toEqual([
+                vec3.fromValues(-0, -0, -1),
+                vec3.fromValues(-0, 0, -1)
+            ]);
         });
         it('can bake a WorkingGeometry that has many merged objects', () => {
             const rootSquare = TestHelper.square();
@@ -128,7 +126,10 @@ describe('WorkingGeometry', () => {
             // Normals should be an array of 8 (indices/3) [0, 0, 1] vectors
             const indexStride = 3;
             const normalCount = bakedObject.indices.length / indexStride;
-            const expectedNormals: vec3[] = range(normalCount).map(() => vec3.fromValues(0, 0, 1));
+            const expectedNormals: vec3[] = range(normalCount).map(
+                (i: number) =>
+                    i % 2 === 0 ? vec3.fromValues(-0, -0, -1) : vec3.fromValues(-0, 0, -1)
+            );
             expect(bakedObject.normals).toEqual(expectedNormals);
         });
     });

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -26,10 +26,7 @@ export namespace TestHelper {
             vec3.fromValues(1, 1, 0),
             vec3.fromValues(1, 0, 0)
         ];
-        const faces = [
-            new Face([0, 1, 2], vec3.fromValues(0, 0, 1)),
-            new Face([0, 2, 3], vec3.fromValues(0, 0, 1))
-        ];
+        const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
         const controlPoints = [start];
 
         const vertices = unitVertices.map((vertex: vec3) => {
@@ -79,23 +76,23 @@ export namespace TestHelper {
         ];
         const faces = [
             // Front side
-            new Face([0, 1, 2], vec3.fromValues(0, 0, -1)),
-            new Face([0, 2, 3], vec3.fromValues(0, 0, -1)),
+            new Face([0, 1, 2]),
+            new Face([0, 2, 3]),
             // Left side
-            new Face([0, 1, 5], vec3.fromValues(-1, 0, 0)),
-            new Face([1, 4, 5], vec3.fromValues(-1, 0, 0)),
+            new Face([0, 1, 5]),
+            new Face([1, 4, 5]),
             // Right side
-            new Face([3, 2, 6], vec3.fromValues(1, 0, 0)),
-            new Face([3, 6, 7], vec3.fromValues(1, 0, 0)),
+            new Face([3, 2, 6]),
+            new Face([3, 6, 7]),
             // Back side
-            new Face([4, 5, 6], vec3.fromValues(0, 0, 1)),
-            new Face([4, 6, 7], vec3.fromValues(0, 0, 1)),
+            new Face([4, 5, 6]),
+            new Face([4, 6, 7]),
             // Top side
-            new Face([1, 2, 6], vec3.fromValues(0, 1, 0)),
-            new Face([1, 5, 6], vec3.fromValues(0, 1, 0)),
+            new Face([1, 2, 6]),
+            new Face([1, 5, 6]),
             // Bottom side
-            new Face([0, 4, 7], vec3.fromValues(0, -1, 0)),
-            new Face([0, 3, 7], vec3.fromValues(0, -1, 0))
+            new Face([0, 4, 7]),
+            new Face([0, 3, 7])
         ];
         const controlPoints = [start];
 


### PR DESCRIPTION
I don't think we should need to specify faces in a working geometry. The face should always be orthogonal to the points specified by the indices of the points.

What we may want (but I currently can't see why) is to specify which of the 2 directions the face is pointing. We can do this by specifying whether the face is the "clockwise" or "anticlockwise" of the cross product of the vectors specified.

Only tested for 3 point faces, but should work for quads as well.

The math: the normal is the cross product between (v1 - v2) and (v2 - v3) in a face that has vertices [v1, v2, v3].