### PR TITLE
Add array of vectors test equality methods

### DIFF
--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -62,12 +62,10 @@ describe('WorkingGeometry', () => {
             const bakedSquare = square.bake();
 
             // Not testing the colors yet since they don't do anything useful
+            const expectedNormal = vec3.fromValues(0, 0, -1);
             expect(bakedSquare.indices).toEqual([0, 1, 2, 0, 2, 3]);
             expect(bakedSquare.vertices).toEqual(vertices);
-            expect(bakedSquare.normals).toEqual([
-                vec3.fromValues(-0, -0, -1),
-                vec3.fromValues(-0, 0, -1)
-            ]);
+            expect(bakedSquare.normals).toEqualArrVec3([expectedNormal, expectedNormal]);
         });
         it('can bake a WorkingGeometry that has many merged objects', () => {
             const rootSquare = TestHelper.square();
@@ -126,11 +124,8 @@ describe('WorkingGeometry', () => {
             // Normals should be an array of 8 (indices/3) [0, 0, 1] vectors
             const indexStride = 3;
             const normalCount = bakedObject.indices.length / indexStride;
-            const expectedNormals: vec3[] = range(normalCount).map(
-                (i: number) =>
-                    i % 2 === 0 ? vec3.fromValues(-0, -0, -1) : vec3.fromValues(-0, 0, -1)
-            );
-            expect(bakedObject.normals).toEqual(expectedNormals);
+            const expectedNormals: vec3[] = range(normalCount).map(() => vec3.fromValues(0, 0, -1));
+            expect(bakedObject.normals).toEqualArrVec3(expectedNormals);
         });
     });
     describe('merge', () => {

--- a/tests/glMatrix.ts
+++ b/tests/glMatrix.ts
@@ -3,6 +3,14 @@ import { mat4, quat, vec3, vec4 } from 'gl-matrix';
 declare global {
     namespace jest {
         interface Matchers<R> {
+            toEqualArrVec3(
+                received: vec4[],
+                argument: vec4[]
+            ): { pass: boolean; message(): string };
+            toEqualArrVec4(
+                received: vec4[],
+                argument: vec4[]
+            ): { pass: boolean; message(): string };
             toEqualMat4(argument: mat4): { pass: boolean; message(): string };
             toEqualVec3(argument: vec3): { pass: boolean; message(): string };
             toEqualVec4(argument: vec4): { pass: boolean; message(): string };
@@ -12,6 +20,62 @@ declare global {
 }
 
 expect.extend({
+    toEqualArrVec4(received: vec4[], argument: vec4[]) {
+        let match: boolean = true;
+        if (received.length !== argument.length) {
+            match = false;
+        }
+        for (let i: number = 0; i < received.length; i += 1) {
+            if (!vec4.equals(received[i], argument[i])) {
+                match = false;
+            }
+        }
+        if (match) {
+            return {
+                message: () =>
+                    `expected ${argument.map(vec4.str).join(',')} to not be equal to ${argument
+                        .map(vec4.str)
+                        .join(',')}`,
+                pass: true
+            };
+        } else {
+            return {
+                message: () =>
+                    `expected ${received.map(vec4.str).join(',')} to be equal to ${argument
+                        .map(vec4.str)
+                        .join(',')}`,
+                pass: false
+            };
+        }
+    },
+    toEqualArrVec3(received: vec3[], argument: vec3[]) {
+        let match: boolean = true;
+        if (received.length !== argument.length) {
+            match = false;
+        }
+        for (let i: number = 0; i < received.length; i += 1) {
+            if (!vec3.equals(received[i], argument[i])) {
+                match = false;
+            }
+        }
+        if (match) {
+            return {
+                message: () =>
+                    `expected ${argument.map(vec3.str).join(',')} to not be equal to ${argument
+                        .map(vec3.str)
+                        .join(',')}`,
+                pass: true
+            };
+        } else {
+            return {
+                message: () =>
+                    `expected ${received.map(vec3.str).join(',')} to be equal to ${argument
+                        .map(vec3.str)
+                        .join(',')}`,
+                pass: false
+            };
+        }
+    },
     toEqualMat4(received: mat4, argument: mat4) {
         if (mat4.equals(received, argument)) {
             return {


### PR DESCRIPTION
This change adds methods to be able to sanely compare arrays of `vec3` and `vec4`s. This also updates tests what previously had to handle -0s weirdly. It uses the equality as defined in `gl-matrix`. For 2 arrays of vectors to be equal to each other, the same vectors must appear in the same order.