### PR TITLE
Fix pointTo

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -105,29 +105,112 @@ export class Node {
         return this;
     }
 
-    public stretchTo(point: Point | vec3, options: {volume?: number} = {}): Node {
-        // Bring the target point into local coordinates
-        const target3 = this.localPointCoordinate(point);
-
-        const volume = (options.volume === undefined) ? null : options.volume;
-        this.pointAndStretch(target3, true, volume);
-
-        return this;
-    }
-
     /**
      * Given the current constraints on the node, rotates the node to look at a point.
      *
      * @param {Point | vec3} point The point to rotate towards.
      */
     public pointAt(point: Point | vec3): Node {
+        if (this.grabbed === null) {
+            throw new Error('You must grab a point before pointing it at something');
+        }
+        const grabbed = vec3ToPoint(this.grabbed);
+
+        // Constrained points must stay in the same location before and after the rotation
+        const constrainedPoints: vec3[] = [...this.held];
+
+        // If the node is attached to a parent node with an anchor, add it to the list of
+        // constrained points.
+        if (this.anchor !== null) {
+            constrainedPoints.push(this.anchor);
+        }
+
         // Bring the target point into local coordinates
         const target3 = this.localPointCoordinate(point);
+        const target = vec3ToPoint(target3);
 
-        this.pointAndStretch(target3, false);
+        // Use the last constrained point as an anchor. If this node was attached to a parent, then
+        // this will be `this.anchor`. Otherwise, it will be some other arbitrary held point.
+        const anchor3 = constrainedPoints.pop();
+        if (anchor3 === undefined) {
+            throw new Error('At least one point must be held or attached to another node');
+        }
+        const anchor = vec3ToPoint(anchor3);
+
+        if (constrainedPoints.length === 0) {
+            // After having popped one constrained point, if there are no remaining points, then
+            // there are two degrees of freedom
+
+            // Create vectors going from the anchor to the
+            const toGrabbed = vec3.sub(vec3.create(), this.grabbed, anchor3);
+            const toTarget = vec3.sub(vec3.create(), target3, anchor3);
+
+            // We want to rotate about an axis perpendicular to the plane defined by the anchor,
+            // the grabbed point, and the target point
+            const axis = vec3.cross(vec3.create(), toGrabbed, toTarget);
+            vec3.normalize(axis, axis);
+
+            // We need to rotate the angle between the vector from anchor to grab point and the
+            // vector from anchor to target point
+            const angle = vec3.angle(toGrabbed, toTarget);
+
+            console.log(target3, anchor3, this.grabbed);
+            console.log(axis, angle);
+
+            // Create a quaternion from the axis and angle
+            this.setRotation(
+                quat.multiply(
+                    quat.create(),
+                    quat.setAxisAngle(quat.create(), axis, angle),
+                    this.getRotation()
+                )
+            );
+        } else if (constrainedPoints.length === 1) {
+            // After having popped one constraine dpoint, if there is another remaining point, then
+            // we only have one degree of freedom, so rotation will be about the axis between the
+            // anchor point and the remaining constrained point
+
+            // Compute the axis between the two constrained points
+            const heldAxis = vec4.sub(vec4.create(), vec3ToPoint(constrainedPoints[0]), anchor);
+            vec4.normalize(heldAxis, heldAxis);
+
+            // Get the vector from the axis to the grabbed point
+            const closestOnAxisToGrab = closestPointOnLine(grabbed, anchor, heldAxis);
+            const toGrabbed = vec4.sub(vec4.create(), grabbed, closestOnAxisToGrab);
+
+            // Get the vector from the axis to the target
+            const closestOnAxisToTarget = closestPointOnLine(target, anchor, heldAxis);
+            const toTarget = vec4.sub(vec4.create(), target, closestOnAxisToTarget);
+
+            // Create an axis that is perpendicular to the vector from axis to target and the vector
+            // from axis to grab point. Even though we already have an axis, it could be pointing
+            // positively or negatively, depending on the order hold points were added. By using
+            // the cross product, we will always have the axis face the same way relative to the two
+            // vectors.
+            const axis = vec3.cross(vec3.create(), vec3From4(toGrabbed), vec3From4(toTarget));
+            vec3.normalize(axis, axis);
+
+            // Get the angle between the vector to the grab point and the vector to the target
+            const angle = vec3.angle(vec3From4(toGrabbed), vec3From4(toTarget));
+
+            // Create a quaternion from the axis and angle
+            this.setRotation(
+                quat.multiply(
+                    quat.create(),
+                    quat.setAxisAngle(quat.create(), axis, angle),
+                    this.getRotation()
+                )
+            );
+        } else {
+            throw new Error(
+                `There are too many held points (${
+                    constrainedPoints.length
+                }), so the node can't be rotated`
+            );
+        }
 
         return this;
-    } 
+    }
 
     public addChild(child: Node) {
         this.children.push(child);
@@ -150,7 +233,17 @@ export class Node {
      * @returns {quat}
      */
     public getRotation(): quat {
-        return mat4.getRotation(quat.create(), this.transformation.transform);
+        return this.transformation.rotation;
+    }
+
+    /**
+     * Sets the rotation for the node by updating the private `transformation`
+     * property.
+     *
+     * @param {quat} rotation
+     */
+    public setRotation(rotation: quat) {
+        this.transformation.rotation = rotation;
     }
 
     /**
@@ -159,7 +252,16 @@ export class Node {
      * @returns {vec3}
      */
     public getScale(): vec3 {
-        return mat4.getScaling(vec3.create(), this.transformation.transform);
+        return this.transformation.scale;
+    }
+
+    /**
+     * Sets the scale for the node by updating the private `transformation` property.
+     *
+     * @param {vec3} scale
+     */
+    public setScale(scale: vec3) {
+        this.transformation.scale = scale;
     }
 
     /**
@@ -169,10 +271,6 @@ export class Node {
      */
     public getPosition(): vec3 {
         return this.transformation.position;
-    }
-
-    public applyTransform(transform: mat4) {
-        mat4.multiply(this.transformation.transform, transform, this.transformation.transform);
     }
 
     /**
@@ -188,8 +286,15 @@ export class Node {
     /**
      * @returns {mat4} A matrix that brings local coordinate into the parent coordinate space.
      */
-    public getMatrix(): mat4 {
-        return this.transformation.getMatrix();
+    public getTransformation(): mat4 {
+        const transform = mat4.fromTranslation(mat4.create(), this.transformation.position);
+        if (this.parent !== null) {
+            mat4.scale(transform, transform, vec3.inverse(vec3.create(), this.parent.getScale()));
+        }
+        mat4.multiply(transform, transform, mat4.fromQuat(mat4.create(), this.transformation.rotation));
+        mat4.scale(transform, transform, this.transformation.scale);
+
+        return transform;
     }
 
     /**
@@ -197,9 +302,9 @@ export class Node {
      * space.
      */
     public localToGlobalTransform(): mat4 {
-        const transform = this.transformation.getMatrix();
+        const transform = this.transformation.getTransformation();
         if (this.parent !== null) {
-            mat4.multiply(transform, transform, this.parent.localToGlobalTransform());
+            mat4.multiply(transform, this.parent.localToGlobalTransform(), transform);
         }
 
         return transform;
@@ -210,7 +315,7 @@ export class Node {
      * space.
      */
     public globalToLocalTransform(): mat4 {
-        const transform = this.transformation.getMatrix();
+        const transform = this.transformation.getTransformation();
         mat4.invert(transform, transform);
 
         if (this.parent !== null) {
@@ -244,7 +349,7 @@ export class Node {
         isRoot: boolean,
         makeBones: boolean
     ): { currentMatrix: mat4; objects: NodeRenderObject } {
-        const currentMatrix = this.transformation.getMatrix();
+        const currentMatrix = this.transformation.getTransformation();
         mat4.multiply(currentMatrix, parentMatrix, currentMatrix);
 
         const objects: NodeRenderObject = this.children.reduce(
@@ -281,8 +386,9 @@ export class Node {
      * to the current node's origin.
      */
     protected boneRenderObject(parentMatrix: mat4): RenderObject {
-        const transform = mat4.fromRotationTranslationScale(
-            mat4.create(),
+        const transform: Transformation = new Transformation(
+            // Since the bone will start at the parent node's origin, we do not need to translate it
+            vec3.fromValues(0, 0, 0),
 
             // Rotate the bone so it points from the parent node's origin to the current node's
             // origin
@@ -291,9 +397,6 @@ export class Node {
                 vec3.fromValues(1, 0, 0),
                 vec3.normalize(vec3.create(), this.transformation.position)
             ),
-
-            // Since the bone will start at the parent node's origin, we do not need to translate it
-            vec3.fromValues(0, 0, 0),
 
             // Scale the bone so its length is equal to the length between the parent node's origin
             // and the current node's origin
@@ -308,7 +411,7 @@ export class Node {
             )
         );
         const transformationMatrix = mat4.create();
-        mat4.multiply(transformationMatrix, parentMatrix, transform);
+        mat4.multiply(transformationMatrix, parentMatrix, transform.getTransformation());
 
         return { ...Node.bone, transform: transformationMatrix, isShadeless: true };
     }
@@ -332,109 +435,19 @@ export class Node {
             // it out of its own node's space into global space
             mat4.multiply(pointToLocal, point.node.localToGlobalTransform(), pointToLocal);
         }
+
         // tslint:disable-next-line:no-use-before-declare
         if (!(point instanceof Point) || point.node !== this) {
             // If the point was given in a coordenate space other than this node's space, it is now
             // in global space after the previous matrix multiply, so we now need to bring it from
             // global into this node's local space.
             mat4.multiply(pointToLocal, this.globalToLocalTransform(), pointToLocal);
+            mat4.scale(pointToLocal, pointToLocal, this.getScale());
         }
+
         const local = vec4.transformMat4(vec4.create(), pointRelative, pointToLocal);
 
         return vec3From4(local);
-    }
-
-    // tslint:disable:max-func-body-length
-    private pointAndStretch(target3: vec3, stretch: boolean, _: number | null = null) {
-        if (this.grabbed === null) {
-            throw new Error('You must grab a point before pointing it at something');
-        }
-        const grabbed = vec3ToPoint(this.grabbed);
-
-        // Constrained points must stay in the same location before and after the rotation
-        const constrainedPoints: vec3[] = [...this.held];
-
-        // If the node is attached to a parent node with an anchor, add it to the list of
-        // constrained points.
-        if (this.anchor !== null) {
-            constrainedPoints.push(this.anchor);
-        }
-
-        const target = vec3ToPoint(target3);
-
-        // Use the last constrained point as an anchor. If this node was attached to a parent, then
-        // this will be `this.anchor`. Otherwise, it will be some other arbitrary held point.
-        const anchor3 = constrainedPoints.pop();
-        if (anchor3 === undefined) {
-            throw new Error('At least one point must be held or attached to another node');
-        }
-        const anchor = vec3ToPoint(anchor3);
-
-        if (constrainedPoints.length === 0) {
-            // After having popped one constrained point, if there are no remaining points, then
-            // there are two degrees of freedom
-
-            // Create vectors going from the anchor to the
-            const toGrabbed = vec3.sub(vec3.create(), this.grabbed, anchor3);
-            const toTarget = vec3.sub(vec3.create(), target3, anchor3);
-
-            // We want to rotate about an axis perpendicular to the plane defined by the anchor,
-            // the grabbed point, and the target point
-            const axis = vec3.cross(vec3.create(), toGrabbed, toTarget);
-            vec3.normalize(axis, axis);
-
-            // We need to rotate the angle between the vector from anchor to grab point and the
-            // vector from anchor to target point
-            const angle = vec3.angle(toGrabbed, toTarget);
-
-            // Create a quaternion from the axis and angle
-            this.applyTransform(mat4.fromRotation(mat4.create(), angle, axis));
-
-            if (stretch) {
-                const transform = mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), axis, [1, 0, 0]));
-                mat4.scale(transform, transform, [vec3.length(toTarget) / vec3.length(toGrabbed), 1, 1]);
-                mat4.multiply(transform, transform, mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), [1, 0, 0], axis)));
-                console.log(mat4.str(transform));
-            }
-        } else if (constrainedPoints.length === 1) {
-            // After having popped one constraine dpoint, if there is another remaining point, then
-            // we only have one degree of freedom, so rotation will be about the axis between the
-            // anchor point and the remaining constrained point
-
-            // Compute the axis between the two constrained points
-            const heldAxis = vec4.sub(vec4.create(), vec3ToPoint(constrainedPoints[0]), anchor);
-            vec4.normalize(heldAxis, heldAxis);
-
-            // Get the vector from the axis to the grabbed point
-            const closestOnAxisToGrab = closestPointOnLine(grabbed, anchor, heldAxis);
-            const toGrabbed = vec4.sub(vec4.create(), grabbed, closestOnAxisToGrab);
-
-            // Get the vector from the axis to the target
-            const closestOnAxisToTarget = closestPointOnLine(target, anchor, heldAxis);
-            const toTarget = vec4.sub(vec4.create(), target, closestOnAxisToTarget);
-
-            // Create an axis that is perpendicular to the vector from axis to target and the vector
-            // from axis to grab point. Even though we already have an axis, it could be pointing
-            // positively or negatively, depending on the order hold points were added. By using
-            // the cross product, we will always have the axis face the same way relative to the two
-            // vectors.
-            const axis = vec3.cross(vec3.create(), vec3From4(toGrabbed), vec3From4(toTarget));
-            vec3.normalize(axis, axis);
-
-            // Get the angle between the vector to the grab point and the vector to the target
-            const angle = vec3.angle(vec3From4(toGrabbed), vec3From4(toTarget));
-
-            // Create a quaternion from the axis and angle
-            this.applyTransform(mat4.fromRotation(mat4.create(), angle, axis));
-        } else {
-            throw new Error(
-                `There are too many held points (${
-                    constrainedPoints.length
-                }), so the node can't be rotated`
-            );
-        }
-
-        return this;
     }
 }
 

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -198,23 +198,27 @@ export class Node {
         this.setRotation(
             mat4.multiply(
                 mat4.create(),
+                this.getRotation(),
                 incRotation,
-                this.getRotation()
             )
         );
     }
 
     public rotateTo2Degrees(anchor3: vec3, target3: vec3, grabbed3: vec3) {
         const scaleMatrix = mat4.fromScaling(mat4.create(), this.getScale());
-
-        // Create vectors going from the anchor to the
-        const toGrabbed = vec4.sub(vec4.create(), vec3ToPoint(grabbed3), vec3ToPoint(anchor3));
-        const toTarget = vec4.sub(vec4.create(), vec3ToPoint(target3), vec3ToPoint(anchor3));
+        const grabbed = vec3ToPoint(grabbed3);
+        const target = vec3ToPoint(target3);
+        const anchor = vec3ToPoint(anchor3);
 
         // Rotation gets applied before scale, so we want to undo this node's scale before
         // calculating the new rotation
-        vec4.transformMat4(toGrabbed, toGrabbed, scaleMatrix);
-        vec4.transformMat4(toTarget, toTarget, scaleMatrix);
+        vec4.transformMat4(grabbed, grabbed, scaleMatrix);
+        vec4.transformMat4(target, target, scaleMatrix);
+        vec4.transformMat4(anchor, anchor, scaleMatrix);
+
+        // Create vectors going from the anchor to the
+        const toGrabbed = vec4.sub(vec4.create(), grabbed, anchor);
+        const toTarget = vec4.sub(vec4.create(), target, anchor);
 
         // Normalize direction vectors
         const toGrabbed3 = vec3From4(toGrabbed);
@@ -235,8 +239,8 @@ export class Node {
         this.setRotation(
             mat4.multiply(
                 mat4.create(),
+                this.getRotation(),
                 incRotation,
-                this.getRotation()
             )
         );
     }

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -138,13 +138,11 @@ export class Node {
             // After having popped one constrained point, if there are no remaining points, then
             // there are two degrees of freedom
             this.rotateTo2Degrees(anchor3, target3, this.grabbed);
-            
         } else if (constrainedPoints.length === 1) {
             // After having popped one constraine dpoint, if there is another remaining point, then
             // we only have one degree of freedom, so rotation will be about the axis between the
             // anchor point and the remaining constrained point
             this.rotateTo1Degree(anchor3, target3, this.grabbed, constrainedPoints[0]);
-
         } else {
             throw new Error(
                 `There are too many held points (${
@@ -186,22 +184,23 @@ export class Node {
         vec3.normalize(toTarget3, toTarget3);
 
         // Move the center of rotation to the anchor
-        const incRotation = mat4.fromTranslation(mat4.create(), vec3.sub(vec3.create(), vec3.create(), anchor3));
+        const incRotation = mat4.fromTranslation(
+            mat4.create(),
+            vec3.sub(vec3.create(), vec3.create(), anchor3)
+        );
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
         // point to the vector from the anchor to the target point
-        mat4.multiply(incRotation, mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)), incRotation);
+        mat4.multiply(
+            incRotation,
+            mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)),
+            incRotation
+        );
 
         // Shift the center back again
         mat4.translate(incRotation, incRotation, anchor3);
 
-        this.setRotation(
-            mat4.multiply(
-                mat4.create(),
-                this.getRotation(),
-                incRotation,
-            )
-        );
+        this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }
 
     public rotateTo2Degrees(anchor3: vec3, target3: vec3, grabbed3: vec3) {
@@ -227,22 +226,23 @@ export class Node {
         vec3.normalize(toTarget3, toTarget3);
 
         // Move the center of rotation to the anchor
-        const incRotation = mat4.fromTranslation(mat4.create(), vec3.sub(vec3.create(), vec3.create(), anchor3));
+        const incRotation = mat4.fromTranslation(
+            mat4.create(),
+            vec3.sub(vec3.create(), vec3.create(), anchor3)
+        );
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
         // point to the vector from the anchor to the target point
-        mat4.multiply(incRotation, mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)), incRotation);
+        mat4.multiply(
+            incRotation,
+            mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)),
+            incRotation
+        );
 
         // Shift the center back again
         mat4.translate(incRotation, incRotation, anchor3);
 
-        this.setRotation(
-            mat4.multiply(
-                mat4.create(),
-                this.getRotation(),
-                incRotation,
-            )
-        );
+        this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }
 
     public addChild(child: Node) {
@@ -425,11 +425,14 @@ export class Node {
 
             // Rotate the bone so it points from the parent node's origin to the current node's
             // origin
-            mat4.fromQuat(mat4.create(), quat.rotationTo(
-                quat.create(),
-                vec3.fromValues(1, 0, 0),
-                vec3.normalize(vec3.create(), this.transformation.position)
-            )),
+            mat4.fromQuat(
+                mat4.create(),
+                quat.rotationTo(
+                    quat.create(),
+                    vec3.fromValues(1, 0, 0),
+                    vec3.normalize(vec3.create(), this.transformation.position)
+                )
+            ),
 
             // Scale the bone so its length is equal to the length between the parent node's origin
             // and the current node's origin

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -114,7 +114,6 @@ export class Node {
         if (this.grabbed === null) {
             throw new Error('You must grab a point before pointing it at something');
         }
-        const grabbed = vec3ToPoint(this.grabbed);
 
         // Constrained points must stay in the same location before and after the rotation
         const constrainedPoints: vec3[] = [...this.held];
@@ -127,7 +126,6 @@ export class Node {
 
         // Bring the target point into local coordinates
         const target3 = this.localPointCoordinate(point);
-        const target = vec3ToPoint(target3);
 
         // Use the last constrained point as an anchor. If this node was attached to a parent, then
         // this will be `this.anchor`. Otherwise, it will be some other arbitrary held point.
@@ -135,72 +133,18 @@ export class Node {
         if (anchor3 === undefined) {
             throw new Error('At least one point must be held or attached to another node');
         }
-        const anchor = vec3ToPoint(anchor3);
 
         if (constrainedPoints.length === 0) {
             // After having popped one constrained point, if there are no remaining points, then
             // there are two degrees of freedom
-
-            // Create vectors going from the anchor to the
-            const toGrabbed = vec3.sub(vec3.create(), this.grabbed, anchor3);
-            const toTarget = vec3.sub(vec3.create(), target3, anchor3);
-
-            // We want to rotate about an axis perpendicular to the plane defined by the anchor,
-            // the grabbed point, and the target point
-            const axis = vec3.cross(vec3.create(), toGrabbed, toTarget);
-            vec3.normalize(axis, axis);
-
-            // We need to rotate the angle between the vector from anchor to grab point and the
-            // vector from anchor to target point
-            const angle = vec3.angle(toGrabbed, toTarget);
-
-            console.log(target3, anchor3, this.grabbed);
-            console.log(axis, angle);
-
-            // Create a quaternion from the axis and angle
-            this.setRotation(
-                quat.multiply(
-                    quat.create(),
-                    quat.setAxisAngle(quat.create(), axis, angle),
-                    this.getRotation()
-                )
-            );
+            this.rotateTo2Degrees(anchor3, target3, this.grabbed);
+            
         } else if (constrainedPoints.length === 1) {
             // After having popped one constraine dpoint, if there is another remaining point, then
             // we only have one degree of freedom, so rotation will be about the axis between the
             // anchor point and the remaining constrained point
+            this.rotateTo1Degree(anchor3, target3, this.grabbed, constrainedPoints[0]);
 
-            // Compute the axis between the two constrained points
-            const heldAxis = vec4.sub(vec4.create(), vec3ToPoint(constrainedPoints[0]), anchor);
-            vec4.normalize(heldAxis, heldAxis);
-
-            // Get the vector from the axis to the grabbed point
-            const closestOnAxisToGrab = closestPointOnLine(grabbed, anchor, heldAxis);
-            const toGrabbed = vec4.sub(vec4.create(), grabbed, closestOnAxisToGrab);
-
-            // Get the vector from the axis to the target
-            const closestOnAxisToTarget = closestPointOnLine(target, anchor, heldAxis);
-            const toTarget = vec4.sub(vec4.create(), target, closestOnAxisToTarget);
-
-            // Create an axis that is perpendicular to the vector from axis to target and the vector
-            // from axis to grab point. Even though we already have an axis, it could be pointing
-            // positively or negatively, depending on the order hold points were added. By using
-            // the cross product, we will always have the axis face the same way relative to the two
-            // vectors.
-            const axis = vec3.cross(vec3.create(), vec3From4(toGrabbed), vec3From4(toTarget));
-            vec3.normalize(axis, axis);
-
-            // Get the angle between the vector to the grab point and the vector to the target
-            const angle = vec3.angle(vec3From4(toGrabbed), vec3From4(toTarget));
-
-            // Create a quaternion from the axis and angle
-            this.setRotation(
-                quat.multiply(
-                    quat.create(),
-                    quat.setAxisAngle(quat.create(), axis, angle),
-                    this.getRotation()
-                )
-            );
         } else {
             throw new Error(
                 `There are too many held points (${
@@ -210,6 +154,91 @@ export class Node {
         }
 
         return this;
+    }
+
+    public rotateTo1Degree(anchor3: vec3, target3: vec3, grabbed3: vec3, held3: vec3) {
+        const target = vec3ToPoint(target3);
+        const anchor = vec3ToPoint(anchor3);
+        const grabbed = vec3ToPoint(grabbed3);
+        const scaleMatrix = mat4.fromScaling(mat4.create(), this.getScale());
+
+        // Compute the axis between the two constrained points
+        const heldAxis = vec4.sub(vec4.create(), vec3ToPoint(held3), anchor);
+        vec4.normalize(heldAxis, heldAxis);
+
+        // Get the vector from the axis to the grabbed point
+        const closestOnAxisToGrab = closestPointOnLine(grabbed, anchor, heldAxis);
+        const toGrabbed = vec4.sub(vec4.create(), grabbed, closestOnAxisToGrab);
+
+        // Get the vector from the axis to the target
+        const closestOnAxisToTarget = closestPointOnLine(target, anchor, heldAxis);
+        const toTarget = vec4.sub(vec4.create(), target, closestOnAxisToTarget);
+
+        // Rotation gets applied before scale, so we want to undo this node's scale before
+        // calculating the new rotation
+        vec4.transformMat4(toGrabbed, toGrabbed, scaleMatrix);
+        vec4.transformMat4(toTarget, toTarget, scaleMatrix);
+
+        // Normalize direction vectors
+        const toGrabbed3 = vec3From4(toGrabbed);
+        const toTarget3 = vec3From4(toTarget);
+        vec3.normalize(toGrabbed3, toGrabbed3);
+        vec3.normalize(toTarget3, toTarget3);
+
+        // Move the center of rotation to the anchor
+        const incRotation = mat4.fromTranslation(mat4.create(), vec3.sub(vec3.create(), vec3.create(), anchor3));
+
+        // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
+        // point to the vector from the anchor to the target point
+        mat4.multiply(incRotation, mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)), incRotation);
+
+        // Shift the center back again
+        mat4.translate(incRotation, incRotation, anchor3);
+
+        this.setRotation(
+            mat4.multiply(
+                mat4.create(),
+                incRotation,
+                this.getRotation()
+            )
+        );
+    }
+
+    public rotateTo2Degrees(anchor3: vec3, target3: vec3, grabbed3: vec3) {
+        const scaleMatrix = mat4.fromScaling(mat4.create(), this.getScale());
+
+        // Create vectors going from the anchor to the
+        const toGrabbed = vec4.sub(vec4.create(), vec3ToPoint(grabbed3), vec3ToPoint(anchor3));
+        const toTarget = vec4.sub(vec4.create(), vec3ToPoint(target3), vec3ToPoint(anchor3));
+
+        // Rotation gets applied before scale, so we want to undo this node's scale before
+        // calculating the new rotation
+        vec4.transformMat4(toGrabbed, toGrabbed, scaleMatrix);
+        vec4.transformMat4(toTarget, toTarget, scaleMatrix);
+
+        // Normalize direction vectors
+        const toGrabbed3 = vec3From4(toGrabbed);
+        const toTarget3 = vec3From4(toTarget);
+        vec3.normalize(toGrabbed3, toGrabbed3);
+        vec3.normalize(toTarget3, toTarget3);
+
+        // Move the center of rotation to the anchor
+        const incRotation = mat4.fromTranslation(mat4.create(), vec3.sub(vec3.create(), vec3.create(), anchor3));
+
+        // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
+        // point to the vector from the anchor to the target point
+        mat4.multiply(incRotation, mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)), incRotation);
+
+        // Shift the center back again
+        mat4.translate(incRotation, incRotation, anchor3);
+
+        this.setRotation(
+            mat4.multiply(
+                mat4.create(),
+                incRotation,
+                this.getRotation()
+            )
+        );
     }
 
     public addChild(child: Node) {
@@ -230,9 +259,9 @@ export class Node {
     /**
      * Gets the node's rotation.
      *
-     * @returns {quat}
+     * @returns {mat4}
      */
-    public getRotation(): quat {
+    public getRotation(): mat4 {
         return this.transformation.rotation;
     }
 
@@ -240,9 +269,9 @@ export class Node {
      * Sets the rotation for the node by updating the private `transformation`
      * property.
      *
-     * @param {quat} rotation
+     * @param {mat4} rotation
      */
-    public setRotation(rotation: quat) {
+    public setRotation(rotation: mat4) {
         this.transformation.rotation = rotation;
     }
 
@@ -291,7 +320,7 @@ export class Node {
         if (this.parent !== null) {
             mat4.scale(transform, transform, vec3.inverse(vec3.create(), this.parent.getScale()));
         }
-        mat4.multiply(transform, transform, mat4.fromQuat(mat4.create(), this.transformation.rotation));
+        mat4.multiply(transform, transform, this.transformation.rotation);
         mat4.scale(transform, transform, this.transformation.scale);
 
         return transform;
@@ -392,11 +421,11 @@ export class Node {
 
             // Rotate the bone so it points from the parent node's origin to the current node's
             // origin
-            quat.rotationTo(
+            mat4.fromQuat(mat4.create(), quat.rotationTo(
                 quat.create(),
                 vec3.fromValues(1, 0, 0),
                 vec3.normalize(vec3.create(), this.transformation.position)
-            ),
+            )),
 
             // Scale the bone so its length is equal to the length between the parent node's origin
             // and the current node's origin
@@ -442,7 +471,7 @@ export class Node {
             // in global space after the previous matrix multiply, so we now need to bring it from
             // global into this node's local space.
             mat4.multiply(pointToLocal, this.globalToLocalTransform(), pointToLocal);
-            mat4.scale(pointToLocal, pointToLocal, this.getScale());
+            //mat4.scale(pointToLocal, pointToLocal, this.getScale());
         }
 
         const local = vec4.transformMat4(vec4.create(), pointRelative, pointToLocal);

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -186,7 +186,7 @@ export class Node {
         // Move the center of rotation to the anchor
         const incRotation = mat4.fromTranslation(
             mat4.create(),
-            vec3.sub(vec3.create(), vec3.create(), anchor3)
+            vec3From4(anchor)
         );
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
@@ -198,7 +198,7 @@ export class Node {
         );
 
         // Shift the center back again
-        mat4.translate(incRotation, incRotation, anchor3);
+        mat4.translate(incRotation, incRotation, vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor)));
 
         this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }
@@ -228,19 +228,19 @@ export class Node {
         // Move the center of rotation to the anchor
         const incRotation = mat4.fromTranslation(
             mat4.create(),
-            vec3.sub(vec3.create(), vec3.create(), anchor3)
+            vec3From4(anchor)
         );
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
         // point to the vector from the anchor to the target point
         mat4.multiply(
             incRotation,
-            mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3)),
-            incRotation
+            incRotation,
+            mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), toGrabbed3, toTarget3))
         );
 
         // Shift the center back again
-        mat4.translate(incRotation, incRotation, anchor3);
+        mat4.translate(incRotation, incRotation, vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor)));
 
         this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -191,10 +191,7 @@ export class Node {
         vec3.normalize(toTarget3, toTarget3);
 
         // Move the center of rotation to the anchor
-        const incRotation = mat4.fromTranslation(
-            mat4.create(),
-            vec3From4(anchor)
-        );
+        const incRotation = mat4.fromTranslation(mat4.create(), vec3From4(anchor));
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
         // point to the vector from the anchor to the target point
@@ -205,7 +202,11 @@ export class Node {
         );
 
         // Shift the center back again
-        mat4.translate(incRotation, incRotation, vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor)));
+        mat4.translate(
+            incRotation,
+            incRotation,
+            vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor))
+        );
 
         this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }
@@ -233,10 +234,7 @@ export class Node {
         vec3.normalize(toTarget3, toTarget3);
 
         // Move the center of rotation to the anchor
-        const incRotation = mat4.fromTranslation(
-            mat4.create(),
-            vec3From4(anchor)
-        );
+        const incRotation = mat4.fromTranslation(mat4.create(), vec3From4(anchor));
 
         // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
         // point to the vector from the anchor to the target point
@@ -247,7 +245,11 @@ export class Node {
         );
 
         // Shift the center back again
-        mat4.translate(incRotation, incRotation, vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor)));
+        mat4.translate(
+            incRotation,
+            incRotation,
+            vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor))
+        );
 
         this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
     }
@@ -321,6 +323,14 @@ export class Node {
      */
     public setPosition(position: vector3) {
         this.transformation.setPosition(position);
+    }
+
+    /**
+     * @returns {mat4} A matrix that brings local coordinate into the parent coordinate space.
+     */
+
+    public getTransformation(): mat4 {
+        return this.transformation.getTransformation();
     }
 
     /**

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -1,21 +1,19 @@
-import { mat4, quat, vec3 } from 'gl-matrix';
+import { mat4, vec3 } from 'gl-matrix';
 
 /**
  * Not intended to be user facing.
  */
 export class Transformation {
     public position: vec3;
-    public rotation: quat;
+    public transform: mat4;
     public scale: vec3;
 
     constructor(
         position: vec3 = vec3.fromValues(0, 0, 0),
-        rotation: quat = quat.create(),
-        scale: vec3 = vec3.fromValues(1, 1, 1)
+        transform: mat4 = mat4.create()
     ) {
         this.position = position;
-        this.rotation = rotation;
-        this.scale = scale;
+        this.transform = transform;
     }
 
     /**
@@ -24,12 +22,11 @@ export class Transformation {
      *
      * @returns {mat4}
      */
-    public getTransformation(): mat4 {
-        return mat4.fromRotationTranslationScale(
+    public getMatrix(): mat4 {
+        return mat4.translate(
             mat4.create(),
-            this.rotation,
-            this.position,
-            this.scale
+            this.transform,
+            this.position
         );
     }
 }

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -1,19 +1,25 @@
-import { mat4, vec3 } from 'gl-matrix';
+import { mat4, quat, vec3 } from 'gl-matrix';
 
 /**
  * Not intended to be user facing.
  */
 export class Transformation {
     public position: vec3;
-    public transform: mat4;
+    public rotation: quat;
     public scale: vec3;
 
     constructor(
         position: vec3 = vec3.fromValues(0, 0, 0),
-        transform: mat4 = mat4.create()
+        rotation: quat = quat.create(),
+        scale: vec3 = vec3.fromValues(1, 1, 1)
     ) {
         this.position = position;
-        this.transform = transform;
+        this.rotation = rotation;
+        this.scale = scale;
+    }
+
+    public getScale(): mat4 {
+        return mat4.fromScaling(mat4.create(), this.scale);
     }
 
     /**
@@ -22,11 +28,11 @@ export class Transformation {
      *
      * @returns {mat4}
      */
-    public getMatrix(): mat4 {
-        return mat4.translate(
-            mat4.create(),
-            this.transform,
-            this.position
-        );
+    public getTransformation(): mat4 {
+        const transform = mat4.fromTranslation(mat4.create(), this.position);
+        mat4.multiply(transform, transform, mat4.fromQuat(mat4.create(), this.rotation));
+        mat4.scale(transform, transform, this.scale);
+
+        return transform;
     }
 }

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -1,25 +1,21 @@
-import { mat4, quat, vec3 } from 'gl-matrix';
+import { mat4, vec3 } from 'gl-matrix';
 
 /**
  * Not intended to be user facing.
  */
 export class Transformation {
     public position: vec3;
-    public rotation: quat;
+    public rotation: mat4;
     public scale: vec3;
 
     constructor(
         position: vec3 = vec3.fromValues(0, 0, 0),
-        rotation: quat = quat.create(),
+        rotation: mat4 = mat4.create(),
         scale: vec3 = vec3.fromValues(1, 1, 1)
     ) {
         this.position = position;
         this.rotation = rotation;
         this.scale = scale;
-    }
-
-    public getScale(): mat4 {
-        return mat4.fromScaling(mat4.create(), this.scale);
     }
 
     /**
@@ -30,7 +26,7 @@ export class Transformation {
      */
     public getTransformation(): mat4 {
         const transform = mat4.fromTranslation(mat4.create(), this.position);
-        mat4.multiply(transform, transform, mat4.fromQuat(mat4.create(), this.rotation));
+        mat4.multiply(transform, transform, this.rotation);
         mat4.scale(transform, transform, this.scale);
 
         return transform;

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -4,7 +4,7 @@ import { genSphere } from '../geometry/Sphere';
 import { Light } from '../renderer/interfaces/Light';
 import { Renderer } from '../renderer/Renderer';
 
-import { mat4, quat, vec3 } from 'gl-matrix';
+import { quat, vec3 } from 'gl-matrix';
 import { range } from 'lodash';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
@@ -39,12 +39,18 @@ range(5).forEach(() => {
     const nextPiece = bone();
     nextPiece.point('base').stickTo(top.point('tip'));
     nextPiece.point('base').attach(sphere);
-    nextPiece.applyTransform(
-        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0))
+    nextPiece.setRotation(
+        quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0)
     );
 
     top = nextPiece;
 });
+
+const test = bone();
+test.setPosition(vec3.fromValues(3, 0, 0));
+test.setScale(vec3.fromValues(1, 3, 1));
+const testChild = bone();
+testChild.point('base').stickTo(test.point('tip'));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 3: set up renderer
@@ -56,10 +62,17 @@ renderer.camera.moveTo(vec3.fromValues(0, 0, 8));
 renderer.camera.lookAt(vec3.fromValues(2, 2, -4));
 
 // Draw the armature
-const incrementalRotation = mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0.1, 0));
+let rotation = 0;
+const angle = Math.random() * 90;
 const draw = () => {
-    tower.applyTransform(incrementalRotation);
-    renderer.draw([tower], { drawAxes: true, drawArmatureBones: true });
+    rotation += 1;
+    tower.setRotation(quat.fromEuler(quat.create(), angle, rotation, 0));
+    test
+        .hold(test.point('base'))
+        .grab(test.point('tip'))
+        .pointAt(tower.point('tip'))
+        .release();
+    renderer.draw([tower, test], { drawAxes: true, drawArmatureBones: true });
     window.requestAnimationFrame(draw);
 };
 draw();

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -40,7 +40,10 @@ range(5).forEach(() => {
     nextPiece.point('base').stickTo(top.point('tip'));
     nextPiece.point('base').attach(sphere);
     nextPiece.setRotation(
-        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0))
+        mat4.fromQuat(
+            mat4.create(),
+            quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0)
+        )
     );
 
     top = nextPiece;
@@ -66,7 +69,9 @@ let rotation = 90;
 const angle = Math.random() * 90;
 const draw = () => {
     rotation += 1;
-    tower.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0)));
+    tower.setRotation(
+        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0))
+    );
     test
         .hold(test.point('base'))
         .grab(test.point('tip'))

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -4,7 +4,7 @@ import { genSphere } from '../geometry/Sphere';
 import { Light } from '../renderer/interfaces/Light';
 import { Renderer } from '../renderer/Renderer';
 
-import { quat, vec3 } from 'gl-matrix';
+import { mat4, quat, vec3 } from 'gl-matrix';
 import { range } from 'lodash';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
@@ -40,7 +40,7 @@ range(5).forEach(() => {
     nextPiece.point('base').stickTo(top.point('tip'));
     nextPiece.point('base').attach(sphere);
     nextPiece.setRotation(
-        quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0)
+        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0))
     );
 
     top = nextPiece;
@@ -48,7 +48,7 @@ range(5).forEach(() => {
 
 const test = bone();
 test.setPosition(vec3.fromValues(3, 0, 0));
-test.setScale(vec3.fromValues(1, 3, 1));
+test.setScale(vec3.fromValues(1, 2, 1));
 const testChild = bone();
 testChild.point('base').stickTo(test.point('tip'));
 
@@ -66,7 +66,7 @@ let rotation = 0;
 const angle = Math.random() * 90;
 const draw = () => {
     rotation += 1;
-    tower.setRotation(quat.fromEuler(quat.create(), angle, rotation, 0));
+    tower.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0)));
     test
         .hold(test.point('base'))
         .grab(test.point('tip'))

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -48,7 +48,7 @@ range(5).forEach(() => {
 
 const test = bone();
 test.setPosition(vec3.fromValues(3, 0, 0));
-test.setScale(vec3.fromValues(1, 2, 1));
+test.setScale(vec3.fromValues(1, 3, 1));
 const testChild = bone();
 testChild.point('base').stickTo(test.point('tip'));
 
@@ -62,7 +62,7 @@ renderer.camera.moveTo(vec3.fromValues(0, 0, 8));
 renderer.camera.lookAt(vec3.fromValues(2, 2, -4));
 
 // Draw the armature
-let rotation = 0;
+let rotation = 90;
 const angle = Math.random() * 90;
 const draw = () => {
     rotation += 1;

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -4,7 +4,7 @@ import { genSphere } from '../geometry/Sphere';
 import { Light } from '../renderer/interfaces/Light';
 import { Renderer } from '../renderer/Renderer';
 
-import { quat, vec3 } from 'gl-matrix';
+import { mat4, quat, vec3 } from 'gl-matrix';
 import { range } from 'lodash';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
@@ -39,8 +39,8 @@ range(5).forEach(() => {
     const nextPiece = bone();
     nextPiece.point('base').stickTo(top.point('tip'));
     nextPiece.point('base').attach(sphere);
-    nextPiece.setRotation(
-        quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0)
+    nextPiece.applyTransform(
+        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), Math.random() * 90 - 45, Math.random() * 90 - 45, 0))
     );
 
     top = nextPiece;
@@ -56,10 +56,9 @@ renderer.camera.moveTo(vec3.fromValues(0, 0, 8));
 renderer.camera.lookAt(vec3.fromValues(2, 2, -4));
 
 // Draw the armature
-let rotation = 0;
+const incrementalRotation = mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0.1, 0));
 const draw = () => {
-    rotation += 1;
-    tower.setRotation(quat.fromEuler(quat.create(), 0, rotation, 0));
+    tower.applyTransform(incrementalRotation);
     renderer.draw([tower], { drawAxes: true, drawArmatureBones: true });
     window.requestAnimationFrame(draw);
 };

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -207,7 +207,7 @@ describe('Node', () => {
             expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
         });
 
-        it('can rotate constrained to an axis a node to look at a point in another node', () => {
+        fit('can rotate constrained to an axis a node to look at a point in another node', () => {
             const parent = bone();
             const child = bone();
             child.createPoint('handle', vec3.fromValues(1, 0.5, 0));
@@ -235,7 +235,7 @@ describe('Node', () => {
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, -90, 0)));
+            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, -90)));
         });
 
         it('can rotate a node to look at a point in another node', () => {
@@ -278,23 +278,6 @@ describe('Node', () => {
 
                 expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)));
             }
-        });
-
-        fit('can rotate a node to look at a point in another node while rotated', () => {
-            const node = bone();
-            node.setScale(vec3.fromValues(1, 2, 1));
-            node.setPosition(vec3.fromValues(4, 0, 0));
-            node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
-
-            const target = bone();
-
-            node
-                .hold(node.point('base'))
-                .grab(node.point('tip'))
-                .pointAt(target.point('base'))
-                .release();
-
-            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, -90)));
         });
     });
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -219,7 +219,7 @@ describe('Node', () => {
             );
         });
 
-        fit('can rotate constrained to an axis a node to look at a point in another node', () => {
+        it('can rotate constrained to an axis a node to look at a point in another node', () => {
             const parent = bone();
             const child = bone();
             child.createPoint('handle', vec3.fromValues(1, 0.5, 0));
@@ -310,10 +310,13 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(1, 1, 0))
                 .release();
 
-            const testPoint = vec4.fromValues(0, 0, 0, 1);
-            vec4.transformMat4(testPoint, testPoint, node.localToGlobalTransform());
+            const tipPoint = vec4.fromValues(0, 1, 0, 1);
+            vec4.transformMat4(tipPoint, tipPoint, node.localToGlobalTransform());
+            expect(tipPoint).toEqualVec4(vec4.fromValues(0, 1, 0, 1));
 
-            expect(testPoint).toEqualVec4(vec4.fromValues(1, 1, 0, 1));
+            const basePoint = vec4.fromValues(0, 0, 0, 1);
+            vec4.transformMat4(basePoint, basePoint, node.localToGlobalTransform());
+            expect(basePoint).toEqualVec4(vec4.fromValues(1, 1, 0, 1));
         });
     });
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -32,7 +32,7 @@ describe('Node', () => {
 
         it('respects rotations', () => {
             const node = bone();
-            node.setRotation(quat.fromEuler(quat.create(), 0, 90, 0));
+            node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 90, 0)));
 
             const point = vec4.fromValues(1, 0, 0, 1);
             vec4.transformMat4(point, point, node.globalToLocalTransform());
@@ -83,7 +83,7 @@ describe('Node', () => {
 
         it('respects rotations', () => {
             const node = bone();
-            node.setRotation(quat.fromEuler(quat.create(), 0, 90, 0));
+            node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 90, 0)));
 
             const point = vec4.fromValues(0, 0, 1, 1);
             vec4.transformMat4(point, point, node.localToGlobalTransform());
@@ -114,10 +114,10 @@ describe('Node', () => {
 
         it('works with nested bones with transforms applied', () => {
             const parent = bone();
-            parent.setRotation(quat.fromEuler(quat.create(), 45, 0, 0));
+            parent.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 45, 0, 0)));
 
             const node = bone();
-            node.setRotation(quat.fromEuler(quat.create(), 45, 0, 0));
+            node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 45, 0, 0)));
             node.point('base').stickTo(parent.point('tip'));
 
             const point = vec4.fromValues(0, 1, 0, 1);
@@ -172,7 +172,7 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, 2))
                 .release();
 
-            expect(node.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 0, -90, 0));
+            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, -90, 0)));
         });
 
         it('rotates a node with two degrees of freedom', () => {
@@ -183,7 +183,7 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, 2))
                 .release();
 
-            expect(node.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, 0, 0));
+            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
         });
 
         it('can rotate a node to look at a global coordinate space point', () => {
@@ -197,14 +197,14 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, -2))
                 .release();
 
-            expect(parent.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), -90, 0, 0));
+            expect(parent.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), -90, 0, 0)));
 
             child
                 .grab(child.point('tip'))
                 .pointAt(vec3.fromValues(0, 1, -1))
                 .release();
 
-            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, 0, 0));
+            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
         });
 
         it('can rotate constrained to an axis a node to look at a point in another node', () => {
@@ -235,7 +235,7 @@ describe('Node', () => {
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, -90, 0));
+            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, -90, 0)));
         });
 
         it('can rotate a node to look at a point in another node', () => {
@@ -257,10 +257,10 @@ describe('Node', () => {
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, 0, 0));
+            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
         });
 
-        fit('can rotate a node to look at a point in another node while transformed', () => {
+        it('can rotate a node to look at a point in another node while transformed', () => {
             const node = bone();
             node.setScale(vec3.fromValues(1, 2, 1));
             node.setPosition(vec3.fromValues(4, 0, 0));
@@ -268,6 +268,8 @@ describe('Node', () => {
             const target = bone();
             //target.setRotation(quat.fromEuler(quat.create(), 45, 0, 0));
 
+            // The transformation should be stable, so the rotation should not change
+            // when we call `pointAt` multiple times in a row
             for (let i = 0; i < 2; i += 1) {
                 node
                     .hold(node.point('base'))
@@ -275,7 +277,7 @@ describe('Node', () => {
                     .pointAt(target.point('tip'))
                     .release();
 
-                expect(node.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180));
+                expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)));
             }
         });
     });
@@ -291,7 +293,7 @@ describe('Node', () => {
             root.setPosition(vec3.fromValues(1, 0, 0));
 
             // Rotate this child matrix 90 degrees about the x-axis.
-            const rotation = quat.fromEuler(quat.create(), 90, 0, 0);
+            const rotation = mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0));
             nodeChild.setRotation(rotation);
 
             /**

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -260,13 +260,12 @@ describe('Node', () => {
             expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
         });
 
-        it('can rotate a node to look at a point in another node while transformed', () => {
+        it('can rotate a node to look at a point in another node while scaled', () => {
             const node = bone();
             node.setScale(vec3.fromValues(1, 2, 1));
             node.setPosition(vec3.fromValues(4, 0, 0));
 
             const target = bone();
-            //target.setRotation(quat.fromEuler(quat.create(), 45, 0, 0));
 
             // The transformation should be stable, so the rotation should not change
             // when we call `pointAt` multiple times in a row
@@ -279,6 +278,23 @@ describe('Node', () => {
 
                 expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)));
             }
+        });
+
+        fit('can rotate a node to look at a point in another node while rotated', () => {
+            const node = bone();
+            node.setScale(vec3.fromValues(1, 2, 1));
+            node.setPosition(vec3.fromValues(4, 0, 0));
+            node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
+
+            const target = bone();
+
+            node
+                .hold(node.point('base'))
+                .grab(node.point('tip'))
+                .pointAt(target.point('base'))
+                .release();
+
+            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, -90)));
         });
     });
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -107,17 +107,19 @@ describe('Node', () => {
                 .release();
 
             child
-                .grab(child.point('tip'))
-                .pointAt(target.point('tip'))
-                .release();
-
-            child
                 .hold(child.point('tip'))
                 .grab(child.point('handle'))
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, -90, 0));
+            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 0, -90, 0));
+
+            //child
+                //.grab(child.point('tip'))
+                //.pointAt(target.point('tip'))
+                //.release();
+
+            expect(child.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 0, 0, 0));
         });
 
         it('can rotate a node to look at a point in another node', () => {
@@ -143,6 +145,46 @@ describe('Node', () => {
         });
     });
 
+    describe('stretchTo', () => {
+        xit('stretch a node about an axis', () => {
+            const node = bone();
+            node.createPoint('handle', vec3.fromValues(1, 0.5, 0));
+
+            /*
+             * Node's control points:
+             *
+             * X      <-- tip
+             * |
+             * |----X <-- handle
+             * |
+             * X      <-- base (at the origin)
+             *
+             */
+
+            node
+                .hold(node.point('base'))
+                .hold(node.point('tip'))
+                .grab(node.point('handle'))
+                .pointAt(vec3.fromValues(0, 0, 2))
+                .release();
+
+            expect(node.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 0, -90, 0));
+        });
+
+        xit('stretches a node with two degrees of freedom', () => {
+            const node = bone();
+            node.createPoint('handle', vec3.fromValues(1, 0.5, 0));
+
+            node
+                .hold(node.point('base'))
+                .grab(node.point('handle'))
+                .stretchTo(vec3.fromValues(0, 0, 2))
+                .release();
+
+            expect(node.getRotation()).toEqualQuat(quat.fromEuler(quat.create(), 90, 0, 0));
+        });
+    })
+
     describe('traverse', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
             const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
@@ -154,8 +196,8 @@ describe('Node', () => {
             root.setPosition(vec3.fromValues(1, 0, 0));
 
             // Rotate this child matrix 90 degrees about the x-axis.
-            const rotation = quat.fromEuler(quat.create(), 90, 0, 0);
-            nodeChild.setRotation(rotation);
+            const rotation = mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0));
+            nodeChild.applyTransform(rotation);
 
             /**
              * Here we're defining a test point and what we expect the result of

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -114,7 +114,9 @@ describe('Node', () => {
 
         it('works with nested bones with transforms applied', () => {
             const parent = bone();
-            parent.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 45, 0, 0)));
+            parent.setRotation(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 45, 0, 0))
+            );
 
             const node = bone();
             node.setRotation(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 45, 0, 0)));
@@ -123,7 +125,9 @@ describe('Node', () => {
             const point = vec4.fromValues(0, 1, 0, 1);
             vec4.transformMat4(point, point, node.localToGlobalTransform());
 
-            expect(point).toEqualVec4(vec4.fromValues(0, Math.sin(Math.PI / 4), 1 + Math.cos(Math.PI / 4), 1));
+            expect(point).toEqualVec4(
+                vec4.fromValues(0, Math.sin(Math.PI / 4), Math.cos(Math.PI / 4) + 1, 1)
+            );
         });
     });
 
@@ -172,7 +176,9 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, 2))
                 .release();
 
-            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, -90, 0)));
+            expect(node.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, -90, 0))
+            );
         });
 
         it('rotates a node with two degrees of freedom', () => {
@@ -183,7 +189,9 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, 2))
                 .release();
 
-            expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
+            expect(node.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0))
+            );
         });
 
         it('can rotate a node to look at a global coordinate space point', () => {
@@ -197,14 +205,18 @@ describe('Node', () => {
                 .pointAt(vec3.fromValues(0, 0, -2))
                 .release();
 
-            expect(parent.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), -90, 0, 0)));
+            expect(parent.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), -90, 0, 0))
+            );
 
             child
                 .grab(child.point('tip'))
                 .pointAt(vec3.fromValues(0, 1, -1))
                 .release();
 
-            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
+            expect(child.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0))
+            );
         });
 
         fit('can rotate constrained to an axis a node to look at a point in another node', () => {
@@ -235,7 +247,9 @@ describe('Node', () => {
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, -90)));
+            expect(child.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, -90))
+            );
         });
 
         it('can rotate a node to look at a point in another node', () => {
@@ -257,7 +271,9 @@ describe('Node', () => {
                 .pointAt(target.point('tip'))
                 .release();
 
-            expect(child.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0)));
+            expect(child.getRotation()).toEqualMat4(
+                mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 90, 0, 0))
+            );
         });
 
         it('can rotate a node to look at a point in another node while scaled', () => {
@@ -276,11 +292,16 @@ describe('Node', () => {
                     .pointAt(target.point('tip'))
                     .release();
 
-                expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)));
+                expect(node.getRotation()).toEqualMat4(
+                    mat4.fromQuat(
+                        mat4.create(),
+                        quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)
+                    )
+                );
             }
         });
 
-        it('can rotate about a point that isn\'t the origin', () => {
+        it("can rotate about a point that isn't the origin", () => {
             const node = bone();
 
             node

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -279,6 +279,21 @@ describe('Node', () => {
                 expect(node.getRotation()).toEqualMat4(mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), 0, 0, Math.atan2(4, 1) / Math.PI * 180)));
             }
         });
+
+        it('can rotate about a point that isn\'t the origin', () => {
+            const node = bone();
+
+            node
+                .hold(node.point('tip'))
+                .grab(node.point('base'))
+                .pointAt(vec3.fromValues(1, 1, 0))
+                .release();
+
+            const testPoint = vec4.fromValues(0, 0, 0, 1);
+            vec4.transformMat4(testPoint, testPoint, node.localToGlobalTransform());
+
+            expect(testPoint).toEqualVec4(vec4.fromValues(1, 1, 0, 1));
+        });
     });
 
     describe('traverse', () => {


### PR DESCRIPTION
I was working on stretchTo but found a bunch of bugs in pointAt that bring back UI A3 puppet flashbacks.

## THE PROBLEMS
- I was making the assumption before that the anchor was always going to be (0, 0, 0). This is not always the case: we need to support rotations about arbitrary axes.
- Rotations were broken when a node has a scale applied to it, because the angle was measured in the scaled coordinate space, but the rotation is applied before scaling when generating the whole transformation matrix.

## THE SOLUTIONS
- Transformations have rotations stored as a matrix now, which allows us to encode a rotation about an arbitrary point.
- Scales are removed after calculating anchor-to-grab and anchor-to-target vectors so that the rotation that gets applied uses the unscaled angle.