### PR TITLE
Add stretchTo

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -398,7 +398,7 @@ export class Node {
             // there are two degrees of freedom
             this.rotateTo2Degrees(anchor3, target3, this.grabbed, stretch);
         } else if (constrainedPoints.length === 1) {
-            // After having popped one constraine dpoint, if there is another remaining point, then
+            // After having popped one constrained point, if there is another remaining point, then
             // we only have one degree of freedom, so rotation will be about the axis between the
             // anchor point and the remaining constrained point
             this.rotateTo1Degree(anchor3, target3, this.grabbed, constrainedPoints[0], stretch);

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -7,12 +7,12 @@ import { matrix4, vector3 } from '../types/VectorTypes';
 export class Transformation {
     private position: vector3;
     private rotation: matrix4;
-    private scale: vector3;
+    private scale: matrix4;
 
     constructor(
         position: vector3 = vec3.fromValues(0, 0, 0),
         rotation: matrix4 = mat4.create(),
-        scale: vector3 = vec3.fromValues(1, 1, 1)
+        scale: matrix4 = mat4.create()
     ) {
         this.position = position;
         this.rotation = rotation;
@@ -28,7 +28,7 @@ export class Transformation {
     public getTransformation(): mat4 {
         const transform = mat4.fromTranslation(mat4.create(), this.getPosition());
         mat4.multiply(transform, transform, this.getRotation());
-        mat4.scale(transform, transform, this.getScale());
+        mat4.multiply(transform, transform, this.getScale());
 
         return transform;
     }
@@ -49,11 +49,11 @@ export class Transformation {
         this.rotation = rotation;
     }
 
-    public getScale(): vec3 {
+    public getScale(): mat4 {
         return this.scale instanceof Function ? this.scale() : this.scale;
     }
 
-    public setScale(scale: vector3) {
+    public setScale(scale: matrix4) {
         this.scale = scale;
     }
 }

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -51,7 +51,7 @@ range(5).forEach(() => {
 
 const test = bone();
 test.setPosition(vec3.fromValues(3, 0, 0));
-test.setScale(vec3.fromValues(1, 3, 1));
+//test.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(1, 3, 1)));
 const testChild = bone();
 testChild.point('base').stickTo(test.point('tip'));
 
@@ -75,7 +75,7 @@ const draw = () => {
     test
         .hold(test.point('base'))
         .grab(test.point('tip'))
-        .pointAt(tower.point('tip'))
+        .stretchTo(tower.point('tip'))
         .release();
     renderer.draw([tower, test], { drawAxes: true, drawArmatureBones: true });
     window.requestAnimationFrame(draw);

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -51,7 +51,7 @@ range(5).forEach(() => {
 
 const test = bone();
 test.setPosition(vec3.fromValues(3, 0, 0));
-//test.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(1, 3, 1)));
+test.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(1, 3, 1)));
 const testChild = bone();
 testChild.point('base').stickTo(test.point('tip'));
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -320,6 +320,55 @@ describe('Node', () => {
         });
     });
 
+    describe('stretchTo', () => {
+        it('brings the grabbed point to the target when there are 2 degrees of freedom', () => {
+            const node = bone();
+            node
+                .hold(node.point('base'))
+                .grab(node.point('tip'))
+                .stretchTo(vec3.fromValues(0, 0, 2))
+                .release();
+
+            // Check that the tip of the bone ends up at the target
+            const testPoint = vec4.fromValues(0, 1, 0, 1);
+            vec4.transformMat4(testPoint, testPoint, node.localToGlobalTransform());
+            expect(testPoint).toEqualVec4(vec4.fromValues(0, 0, 2, 1));
+        });
+
+        it('brings the grabbed point to the target when there are 2 degrees of freedom and an initial scale', () => {
+            const node = bone();
+            node.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(2, 3, 5)));
+
+            node
+                .hold(node.point('base'))
+                .grab(node.point('tip'))
+                .stretchTo(vec3.fromValues(0, 0, 2))
+                .release();
+
+            // Check that the tip of the bone ends up at the target
+            const testPoint = vec4.fromValues(0, 1, 0, 1);
+            vec4.transformMat4(testPoint, testPoint, node.localToGlobalTransform());
+            expect(testPoint).toEqualVec4(vec4.fromValues(0, 0, 2, 1));
+        });
+
+        it('brings the grabbed point as close as it can to the target when there is 1 degree of freedom', () => {
+            const node = bone();
+            node.createPoint('handle', vec3.fromValues(1, 0.5, 0));
+
+            node
+                .hold(node.point('base'))
+                .hold(node.point('tip'))
+                .grab(node.point('handle'))
+                .stretchTo(vec3.fromValues(0, 0, 2))
+                .release();
+
+            // Check that the handle of the bone ends up at the target
+            const testPoint = vec4.fromValues(1, 0.5, 0, 1);
+            vec4.transformMat4(testPoint, testPoint, node.localToGlobalTransform());
+            expect(testPoint).toEqualVec4(vec4.fromValues(0, 0.5, 2, 1));
+        });
+    });
+
     describe('traverse', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
             const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -42,7 +42,7 @@ describe('Node', () => {
 
         it('respects scale', () => {
             const node = bone();
-            node.setScale(vec3.fromValues(2, 1, 1));
+            node.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(2, 1, 1)));
 
             const point = vec4.fromValues(1, 0, 0, 1);
             vec4.transformMat4(point, point, node.globalToLocalTransform());
@@ -93,7 +93,7 @@ describe('Node', () => {
 
         it('respects scale', () => {
             const node = bone();
-            node.setScale(vec3.fromValues(2, 1, 1));
+            node.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(2, 1, 1)));
 
             const point = vec4.fromValues(0.5, 0, 0, 1);
             vec4.transformMat4(point, point, node.localToGlobalTransform());
@@ -278,7 +278,7 @@ describe('Node', () => {
 
         it('can rotate a node to look at a point in another node while scaled', () => {
             const node = bone();
-            node.setScale(vec3.fromValues(1, 2, 1));
+            node.setScale(mat4.fromScaling(mat4.create(), vec3.fromValues(1, 2, 1)));
             node.setPosition(vec3.fromValues(4, 0, 0));
 
             const target = bone();


### PR DESCRIPTION
Since stretching is like an additional option that can be done when pointing at something, I did some small refactoring. Now, there are private internal methods to point and optionally stretch, which in turn may call another private method to do the stretching based on the anchor, axis, and length.

Additionally, scale is a matrix so that we can support scaling about an arbitrary axis.