### PR TITLE
Add initial animation API

### DIFF
--- a/src/armature/Animation.ts
+++ b/src/armature/Animation.ts
@@ -87,12 +87,11 @@ export namespace Animation {
         queue.sort((a: AnimationDescription, b: AnimationDescription) => {
             if (a.start < b.start) {
                 return -1;
-            }
-            if (a.start > b.start) {
+            } else if (a.start > b.start) {
                 return 1;
+            } else {
+                return 0;
             }
-
-            return 0;
         });
     }
 

--- a/src/armature/Animation.ts
+++ b/src/armature/Animation.ts
@@ -1,0 +1,112 @@
+import { Node } from './Node';
+import { Transformation } from './Transformation';
+
+type AnimationDescription = {
+    node: Node;
+    to: Transformation;
+    curve: string;
+    start: number;
+    duration: number;
+    times: number;
+    repeatDelay: number;
+};
+
+type AnimationDescriptionParams = {
+    node: Node;
+    to: (node: Node) => void;
+    curve?: string;
+    start?: number;
+    duration: number;
+    times?: number;
+    repeatDelay?: number;
+};
+
+export namespace Animation {
+    const queue: AnimationDescription[] = [];
+    let current: AnimationDescription[] = [];
+
+    export function now(): number {
+        return new Date().getTime();
+    }
+
+    export function create(params: AnimationDescriptionParams) {
+        const finalNode = Node.clone(params.node);
+        params.to(finalNode);
+
+        const animation = {
+            node: params.node,
+            to: finalNode.getRawTransformation(),
+            curve: params.curve !== undefined ? params.curve : 'linear',
+            start: params.start !== undefined ? params.start : now(),
+            duration: params.duration,
+            times: params.times !== undefined ? params.times : 1,
+            repeatDelay: params.repeatDelay !== undefined ? params.repeatDelay : 0
+        };
+
+        enqueue(animation);
+    }
+
+    export function tick() {
+        const currentTime = now();
+
+        dequeueNewAnimations(currentTime);
+        applyCurrentAnimations(currentTime);
+        removeFinishedAnimations(currentTime);
+    }
+
+    function enqueue(animation: AnimationDescription) {
+        // TODO: binary search instead of insert + sort
+        queue.push(animation);
+        queue.sort((a: AnimationDescription, b: AnimationDescription) => {
+            if (a.start < b.start) {
+                return -1;
+            }
+            if (a.start > b.start) {
+                return 1;
+            }
+
+            return 0;
+        });
+    }
+
+    function dequeueNewAnimations(currentTime: number) {
+        while (queue.length > 0 && queue[0].start <= currentTime) {
+            current.push(queue[0]);
+            queue.shift();
+        }
+    }
+
+    function applyCurrentAnimations(currentTime: number) {
+        // TODO: use curves that aren't linear
+        current.forEach((animation: AnimationDescription) => {
+            const currentTransform = animation.node.getRawTransformation();
+
+            const period = animation.duration + animation.repeatDelay;
+
+            let currentCycle = Math.floor(currentTime / period);
+            if (animation.times > 0) {
+                currentCycle = Math.max(animation.times, currentCycle);
+            }
+
+            let amount = (currentTime - animation.start - currentCycle * period) / animation.duration;
+            amount = Math.max(0, amount);
+            amount = Math.min(1, amount);
+
+            animation.node.setRawTransformation(currentTransform.interpolate(animation.to, amount));
+        })
+    }
+
+    function removeFinishedAnimations(currentTime: number) {
+        current = current.filter((animation: AnimationDescription) => {
+            if (animation.times === 0) {
+                return true;
+            }
+
+            if (animation.times === 1) {
+                return (currentTime - animation.start) / (animation.duration) < 1;
+            }
+
+            return (currentTime - animation.start) / (animation.duration + animation.repeatDelay) < animation.times;
+        });
+    }
+};

--- a/src/armature/Animation.ts
+++ b/src/armature/Animation.ts
@@ -30,15 +30,26 @@ export namespace Animation {
     const queue: AnimationDescription[] = [];
     const current: AnimationDescription[] = [];
 
+    /**
+     * Clears all current animations.
+     */
     export function resetAll() {
         queue.length = 0;
         current.length = 0;
     }
 
+    /**
+     * @returns {number} The current time, in milliseconds since the epoch.
+     */
     export function now(): number {
         return new Date().getTime();
     }
 
+    /**
+     * Creates and queues up an animation with the given parameters.
+     *
+     * @param {AnimationDescriptionParams} params The information about the new animation.
+     */
     export function create(params: AnimationDescriptionParams) {
         const animation = {
             node: params.node,
@@ -56,6 +67,9 @@ export namespace Animation {
         enqueue(animation);
     }
 
+    /**
+     * Updates the state of all animations according to the current time.
+     */
     export function tick() {
         const currentTime = Animation.now();
 
@@ -64,6 +78,9 @@ export namespace Animation {
         removeFinishedAnimations(currentTime);
     }
 
+    /**
+     * Adds an animation to the queue, ensuring that the queue is kept in order of start time.
+     */
     function enqueue(animation: AnimationDescription) {
         // TODO: binary search instead of insert + sort
         queue.push(animation);
@@ -79,6 +96,9 @@ export namespace Animation {
         });
     }
 
+    /**
+     * Moves all animations that should be running from the queue and puts them into `current`.
+     */
     function dequeueNewAnimations(currentTime: number) {
         while (queue.length > 0 && queue[0].start <= currentTime) {
             current.push(queue[0]);
@@ -86,6 +106,10 @@ export namespace Animation {
         }
     }
 
+    /**
+     * Updates the nodes for all currently active animations, interpolating between the given
+     * animation states.
+     */
     function applyCurrentAnimations(currentTime: number) {
         // TODO: use curves that aren't linear
         current.forEach((animation: AnimationDescription) => {
@@ -98,22 +122,29 @@ export namespace Animation {
             }
 
             const timeInCurrentCycle = currentTime - animation.start - currentCycle * period;
-            if (
-                animation.finalTransform === null ||
-                (animation.lastCycle < currentCycle &&
-                    (animation.times === 0 || currentCycle < animation.times))
-            ) {
-                // We've looped into a new cycle
+            const remainingTargetsExist = animation.times === 0 || currentCycle < animation.times;
+            const inNewCycle = animation.lastCycle < currentCycle;
+
+            // Recompute target state of animation if we have entered a new cycle
+            if (animation.finalTransform === null || (inNewCycle && remainingTargetsExist)) {
                 animation.lastTimeInCycle = 0;
+
+                // Clone the current node and apply the callback to generate the target state
                 const finalNode = Node.clone(animation.node);
                 animation.to(finalNode);
+
+                // Extract the transformation from the modified node
                 animation.finalTransform = finalNode.getRawTransformation();
             }
+
             const timeRemainingInCycle = animation.duration - animation.lastTimeInCycle;
             let amount = (timeInCurrentCycle - animation.lastTimeInCycle) / timeRemainingInCycle;
-            if (amount > 1 && (animation.times === 0 || currentCycle < animation.times - 1)) {
+
+            // If we are in the delay period between cycles, do nothing and exit early
+            if (amount > 1 && remainingTargetsExist) {
                 return;
             }
+
             amount = Math.max(0, amount);
             amount = Math.min(1, amount);
 
@@ -125,6 +156,9 @@ export namespace Animation {
         });
     }
 
+    /**
+     * Remove animations that have entirely completed from `current`.
+     */
     function removeFinishedAnimations(currentTime: number) {
         remove(current, (animation: AnimationDescription) => {
             if (animation.times === 0) {

--- a/src/armature/Animation.ts
+++ b/src/armature/Animation.ts
@@ -162,16 +162,15 @@ export namespace Animation {
         remove(current, (animation: AnimationDescription) => {
             if (animation.times === 0) {
                 return false;
-            }
-
-            if (animation.times === 1) {
+            } else if (animation.times === 1) {
                 return (currentTime - animation.start) / animation.duration >= 1;
+            } else {
+                return (
+                    (currentTime - animation.start) /
+                        (animation.duration + animation.repeatDelay) >=
+                    animation.times
+                );
             }
-
-            return (
-                (currentTime - animation.start) / (animation.duration + animation.repeatDelay) >=
-                animation.times
-            );
         });
     }
 }

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -61,7 +61,12 @@ export class Node {
     }
 
     public static clone(node: Node): Node {
-        const cloned = new Node(node.children, node.getPosition(), node.getRotation(), node.getScale());
+        const cloned = new Node(
+            node.children,
+            node.getPosition(),
+            node.getRotation(),
+            node.getScale()
+        );
         cloned.parent = node.parent;
         Object.keys(node.points).forEach((key: string) => {
             cloned.createPoint(key, node.points[key].position);

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -61,7 +61,7 @@ export class Node {
     }
 
     public static clone(node: Node): Node {
-        const cloned = new Node(node.children, node.getPosition(), node.getRotation());
+        const cloned = new Node(node.children, node.getPosition(), node.getRotation(), node.getScale());
         cloned.parent = node.parent;
         Object.keys(node.points).forEach((key: string) => {
             cloned.createPoint(key, node.points[key].position);

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -60,6 +60,17 @@ export class Node {
         this.transformation = new Transformation(position, rotation, scale);
     }
 
+    public static clone(node: Node): Node {
+        const cloned = new Node(node.children, node.getPosition(), node.getRotation());
+        cloned.parent = node.parent;
+        Object.keys(node.points).forEach((key: string) => {
+            cloned.createPoint(key, node.points[key].position);
+        });
+        cloned.anchor = node.anchor;
+
+        return cloned;
+    }
+
     public createPoint(name: string, position: vec3) {
         // tslint:disable-next-line:no-use-before-declare
         this.points[name] = new Point(this, position);
@@ -205,9 +216,25 @@ export class Node {
     /**
      * @returns {mat4} A matrix that brings local coordinate into the parent coordinate space.
      */
-
     public getTransformation(): mat4 {
         return this.transformation.getTransformation();
+    }
+
+    /**
+     * @internal
+     *
+     * @returns {Transformation} The transformation for this node separated into its components
+     */
+    public getRawTransformation(): Transformation {
+        return this.transformation;
+    }
+
+    /**
+     * @internal
+     * Sets the transformation for this node, separated into its components
+     */
+    public setRawTransformation(transformation: Transformation) {
+        this.transformation = transformation;
     }
 
     /**

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -66,25 +66,28 @@ export class Transformation {
 
         // No need to extract scale from rotation matrix, since it should never be scaled
         const rotationOffsetBegin = mat4.getTranslation(vec3.create(), this.getRotation());
-        const rotationOffsetEnd = mat4.getTranslation(vec3.create(), interpolated.getRotation());
+        const rotationOffsetEnd = mat4.getTranslation(vec3.create(), other.getRotation());
         const rotationRotationBegin = mat4.getRotation(quat.create(), this.getRotation());
-        const rotationRotationEnd = mat4.getRotation(quat.create(), interpolated.getRotation());
+        const rotationRotationEnd = mat4.getRotation(quat.create(), other.getRotation());
+        const rotationScaleBegin = mat4.getScaling(vec3.create(), this.getRotation());
+        const rotationScaleEnd = mat4.getScaling(vec3.create(), other.getRotation());
         interpolated.setRotation(
-            mat4.fromRotationTranslation(
+            mat4.fromRotationTranslationScale(
                 interpolated.getRotation(),
                 quat.slerp(quat.create(), rotationRotationBegin, rotationRotationEnd, amount),
-                vec3.lerp(vec3.create(), rotationOffsetBegin, rotationOffsetEnd, amount)
+                vec3.lerp(vec3.create(), rotationOffsetBegin, rotationOffsetEnd, amount),
+                vec3.lerp(vec3.create(), rotationScaleBegin, rotationScaleEnd, amount)
             )
         );
 
         // Because we scale about arbitrary axes, we need to extract and interpolate position,
         // rotation, and scale separately
         const scaleOffsetBegin = mat4.getTranslation(vec3.create(), this.getScale());
-        const scaleOffsetEnd = mat4.getTranslation(vec3.create(), interpolated.getScale());
+        const scaleOffsetEnd = mat4.getTranslation(vec3.create(), other.getScale());
         const scaleRotationBegin = mat4.getRotation(quat.create(), this.getScale());
-        const scaleRotationEnd = mat4.getRotation(quat.create(), interpolated.getScale());
+        const scaleRotationEnd = mat4.getRotation(quat.create(), other.getScale());
         const scaleScaleBegin = mat4.getScaling(vec3.create(), this.getScale());
-        const scaleScaleEnd = mat4.getScaling(vec3.create(), interpolated.getScale());
+        const scaleScaleEnd = mat4.getScaling(vec3.create(), other.getScale());
         interpolated.setScale(
             mat4.fromRotationTranslationScale(
                 interpolated.getScale(),

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -94,7 +94,7 @@ export class Transformation {
                 interpolated.getScale(),
                 quat.slerp(quat.create(), scaleRotationBegin, scaleRotationEnd, amount),
                 vec3.lerp(vec3.create(), scaleOffsetBegin, scaleOffsetEnd, amount),
-                vec3.lerp(vec3.create(), scaleScaleBegin, scaleScaleEnd, amount),
+                vec3.lerp(vec3.create(), scaleScaleBegin, scaleScaleEnd, amount)
             )
         );
 

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -57,6 +57,15 @@ export class Transformation {
         this.scale = scale;
     }
 
+    /**
+     * Creates a new transformation that is between the current one and the provided one, with a
+     * given mix proportion.
+     *
+     * @param {Transformation} other The other transformation to interpolate towards.
+     * @param {number} amount The proportion to mix the transformations, where 0 is entirely the
+     * current transformation and 1 is entirely the other transformation.
+     * @returns {Transformation} The interpolated transformation.
+     */
     public interpolate(other: Transformation, amount: number): Transformation {
         const interpolated = new Transformation();
 
@@ -64,6 +73,8 @@ export class Transformation {
             vec3.lerp(interpolated.getPosition(), this.getPosition(), other.getPosition(), amount)
         );
 
+        // To interpolate matrices, we have to factor them into components and interpolate each
+        // part separately
         const rotationOffsetBegin = mat4.getTranslation(vec3.create(), this.getRotation());
         const rotationOffsetEnd = mat4.getTranslation(vec3.create(), other.getRotation());
         const rotationRotationBegin = mat4.getRotation(quat.create(), this.getRotation());

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -64,11 +64,12 @@ export class Transformation {
             vec3.lerp(interpolated.getPosition(), this.getPosition(), other.getPosition(), amount)
         );
 
-        // No need to extract scale from rotation matrix, since it should never be scaled
         const rotationOffsetBegin = mat4.getTranslation(vec3.create(), this.getRotation());
         const rotationOffsetEnd = mat4.getTranslation(vec3.create(), other.getRotation());
         const rotationRotationBegin = mat4.getRotation(quat.create(), this.getRotation());
         const rotationRotationEnd = mat4.getRotation(quat.create(), other.getRotation());
+        quat.normalize(rotationRotationBegin, rotationRotationBegin);
+        quat.normalize(rotationRotationEnd, rotationRotationEnd);
         const rotationScaleBegin = mat4.getScaling(vec3.create(), this.getRotation());
         const rotationScaleEnd = mat4.getScaling(vec3.create(), other.getRotation());
         interpolated.setRotation(
@@ -80,12 +81,12 @@ export class Transformation {
             )
         );
 
-        // Because we scale about arbitrary axes, we need to extract and interpolate position,
-        // rotation, and scale separately
         const scaleOffsetBegin = mat4.getTranslation(vec3.create(), this.getScale());
         const scaleOffsetEnd = mat4.getTranslation(vec3.create(), other.getScale());
         const scaleRotationBegin = mat4.getRotation(quat.create(), this.getScale());
         const scaleRotationEnd = mat4.getRotation(quat.create(), other.getScale());
+        quat.normalize(scaleRotationBegin, scaleRotationBegin);
+        quat.normalize(scaleRotationEnd, scaleRotationEnd);
         const scaleScaleBegin = mat4.getScaling(vec3.create(), this.getScale());
         const scaleScaleEnd = mat4.getScaling(vec3.create(), other.getScale());
         interpolated.setScale(

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -86,6 +86,7 @@ Animation.create({
         node.setRotation(
             mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), theta, phi, 0))
         );
+        node.setScale(mat4.create());
     },
     duration: 1000,
     times: 0,
@@ -93,11 +94,6 @@ Animation.create({
 });
 
 const draw = () => {
-    //rotation += 1;
-    //tower.setRotation(
-        //mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0))
-    //);
-
     return {
         objects: [tower, test],
         debugParams: { drawAxes: true, drawArmatureBones: true }

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -1,3 +1,4 @@
+import { Animation } from '../armature/Animation';
 import { Armature } from '../armature/Armature';
 import { Node } from '../armature/Node';
 import { genSphere } from '../geometry/Sphere';
@@ -66,8 +67,6 @@ renderer.camera.moveTo(vec3.fromValues(0, 0, 8));
 renderer.camera.lookAt(vec3.fromValues(2, 2, -4));
 
 // Draw the armature
-let rotation = 90;
-const angle = Math.random() * 90;
 
 // Create a new constraint to be applied to the `test` Node.
 const constraints = Constraints.getInstance();
@@ -79,11 +78,25 @@ constraints.add(test, (node: Node) => {
         .release();
 });
 
+Animation.create({
+    node: tower, 
+    to: (node: Node) => {
+        const theta = Math.random() * 90;
+        const phi = Math.random() * 360;
+        node.setRotation(
+            mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), theta, phi, 0))
+        );
+    },
+    duration: 1000,
+    times: 0,
+    repeatDelay: 0
+});
+
 const draw = () => {
-    rotation += 1;
-    tower.setRotation(
-        mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0))
-    );
+    //rotation += 1;
+    //tower.setRotation(
+        //mat4.fromQuat(mat4.create(), quat.fromEuler(quat.create(), angle, rotation, 0))
+    //);
 
     return {
         objects: [tower, test],

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -79,7 +79,7 @@ constraints.add(test, (node: Node) => {
 });
 
 Animation.create({
-    node: tower, 
+    node: tower,
     to: (node: Node) => {
         const theta = Math.random() * 90;
         const phi = Math.random() * 360;

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -9,6 +9,7 @@ import { mat4, vec3, vec4 } from 'gl-matrix';
 
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
+import { Animation } from '../armature/Animation';
 import { Constraints } from '../armature/Constraints';
 import { Node } from '../armature/Node';
 import { DebugParams } from './interfaces/DebugParams';
@@ -210,6 +211,7 @@ export class Renderer {
     public eachFrame(drawCallback: () => RenderParams) {
         const draw = () => {
             const { objects, debugParams } = drawCallback();
+            Animation.tick();
             Constraints.getInstance().applyAll();
             this.draw(
                 objects,

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -215,7 +215,7 @@ export class Renderer {
             Constraints.getInstance().applyAll();
             this.draw(
                 objects,
-                debugParams === undefined
+                debugParams !== undefined
                     ? debugParams
                     : { drawAxes: false, drawArmatureBones: false }
             );

--- a/tests/armature/Animation.spec.ts
+++ b/tests/armature/Animation.spec.ts
@@ -1,0 +1,148 @@
+import { vec3 } from 'gl-matrix';
+import { Animation } from '../../src/armature/Animation';
+import { Armature } from '../../src/armature/Armature';
+import { Node } from '../../src/armature/Node';
+import { Transformation } from '../../src/armature/Transformation';
+
+const bone = Armature.define((root: Node) => {
+    root.createPoint('base', vec3.fromValues(0, 0, 0));
+    root.createPoint('tip', vec3.fromValues(0, 1, 0));
+});
+
+describe('Animation', () => {
+    const realNow = Animation.now;
+    const realInterpolate = Transformation.prototype.interpolate;
+
+    const mockNow = (date: number) => {
+        Animation.now = () => date;
+    };
+
+    beforeEach(() => Animation.resetAll());
+    afterEach(() => (Animation.now = realNow));
+    afterEach(() => (Transformation.prototype.interpolate = realInterpolate));
+
+    describe('tick', () => {
+        it('only applies animations when they are active', () => {
+            const node = bone();
+            const animationApplied = jest.fn();
+
+            mockNow(1000);
+
+            Animation.create({
+                node,
+                to: (_: Node) => animationApplied(),
+                start: 2000,
+                duration: 1000
+            });
+
+            Animation.tick();
+
+            // Animation shouldn't be applied yet, it hasn't started
+            expect(animationApplied.mock.calls.length).toBe(0);
+
+            mockNow(2000);
+            Animation.tick();
+
+            // Animation should have been applied, since it has now started
+            expect(animationApplied.mock.calls.length).toBe(1);
+
+            mockNow(5000);
+            Animation.tick();
+
+            // No new applications should have been made, since the animation has ended
+            expect(animationApplied.mock.calls.length).toBe(1);
+        });
+
+        it('runs animations the specified amount of times', () => {
+            const node = bone();
+            const animationApplied = jest.fn();
+
+            mockNow(1000);
+
+            Animation.create({
+                node,
+                to: (_: Node) => animationApplied(),
+                start: 2000,
+                duration: 1000,
+                times: 2,
+                repeatDelay: 1000
+            });
+
+            Animation.tick();
+
+            // Animation shouldn't be applied yet, it hasn't started
+            expect(animationApplied.mock.calls.length).toBe(0);
+
+            mockNow(2000);
+            Animation.tick();
+
+            // Animation should have been applied, since it has now started
+            expect(animationApplied.mock.calls.length).toBe(1);
+
+            mockNow(3000);
+            Animation.tick();
+
+            // No new applications should have been made, since the animation is waiting
+            // for the next iteration
+            expect(animationApplied.mock.calls.length).toBe(1);
+
+            mockNow(4000);
+            Animation.tick();
+
+            // The second iteration of the animation has started by now, should be applied again
+            expect(animationApplied.mock.calls.length).toBe(2);
+
+            mockNow(5000);
+            Animation.tick();
+
+            // No new applications should have been made, since the animation has ended
+            expect(animationApplied.mock.calls.length).toBe(2);
+        });
+
+        it('accurately calculates how many subdivisions are left when interpolating', () => {
+            const node = bone();
+            const interpolate = jest.fn(() => new Transformation());
+            Transformation.prototype.interpolate = interpolate;
+
+            mockNow(1000);
+
+            Animation.create({
+                node,
+                to: (_: Node) => {},
+                start: 2000,
+                duration: 1000
+            });
+
+            mockNow(2000);
+            Animation.tick();
+
+            // Animation should have been applied, asking for the first subdivision
+            expect(interpolate.mock.calls.length).toBe(1);
+            expect(interpolate.mock.calls[0][1]).toBe(0);
+
+            mockNow(2500);
+            Animation.tick();
+
+            // Animation should have been applied again. Since we are halfway between the last
+            // tick and the end of the animation, we should interpolate halfway.
+            expect(interpolate.mock.calls.length).toBe(2);
+            expect(interpolate.mock.calls[1][1]).toBe(0.5);
+
+            mockNow(2875);
+            Animation.tick();
+
+            // Animation should have been applied again. Since we moved 75% from the last tick
+            // to the end of the animation, we should interpolate by 0.75.
+            expect(interpolate.mock.calls.length).toBe(3);
+            expect(interpolate.mock.calls[2][1]).toBe(0.75);
+
+            mockNow(3000);
+            Animation.tick();
+
+            // Animation should have been applied again. Since we moved all the way to the end
+            // of the animation, we should interpolate by 1.
+            expect(interpolate.mock.calls.length).toBe(4);
+            expect(interpolate.mock.calls[3][1]).toBe(1);
+        });
+    });
+});

--- a/tests/armature/Animation.spec.ts
+++ b/tests/armature/Animation.spec.ts
@@ -30,7 +30,9 @@ describe('Animation', () => {
 
             Animation.create({
                 node,
-                to: (_: Node) => animationApplied(),
+                to: (_: Node) => {
+                    animationApplied();
+                },
                 start: 2000,
                 duration: 1000
             });
@@ -61,7 +63,9 @@ describe('Animation', () => {
 
             Animation.create({
                 node,
-                to: (_: Node) => animationApplied(),
+                to: (_: Node) => {
+                    animationApplied();
+                },
                 start: 2000,
                 duration: 1000,
                 times: 2,

--- a/tests/armature/Transformation.spec.ts
+++ b/tests/armature/Transformation.spec.ts
@@ -1,0 +1,41 @@
+import { mat4, vec3 } from 'gl-matrix';
+import { Transformation } from '../../src/armature/Transformation';
+import '../glMatrix';
+
+describe('Transformation', () => {
+    describe('interpolate', () => {
+        it('returns a copy of itself when the amount is 0', () => {
+            const initialTransform = new Transformation(
+                vec3.fromValues(1, 2, 3),
+                mat4.fromRotation(mat4.create(), 90, vec3.fromValues(1, 0, 0)),
+                mat4.fromScaling(mat4.create(), vec3.fromValues(1, 2, 3))
+            );
+            const finalTransform = new Transformation(
+                vec3.fromValues(1, 2, 3),
+                mat4.fromRotation(mat4.create(), 90, vec3.fromValues(1, 0, 0)),
+                mat4.fromScaling(mat4.create(), vec3.fromValues(1, 2, 3))
+            );
+
+            expect(initialTransform.interpolate(finalTransform, 0).getTransformation()).toEqualMat4(
+                initialTransform.getTransformation()
+            );
+        });
+
+        it('returns a copy of the final transform when the amount is 1', () => {
+            const initialTransform = new Transformation(
+                vec3.fromValues(1, 2, 3),
+                mat4.fromRotation(mat4.create(), 90, vec3.fromValues(1, 0, 0)),
+                mat4.fromScaling(mat4.create(), vec3.fromValues(1, 2, 3))
+            );
+            const finalTransform = new Transformation(
+                vec3.fromValues(1, 2, 3),
+                mat4.fromRotation(mat4.create(), 90, vec3.fromValues(1, 0, 0)),
+                mat4.fromScaling(mat4.create(), vec3.fromValues(1, 2, 3))
+            );
+
+            expect(initialTransform.interpolate(finalTransform, 1).getTransformation()).toEqualMat4(
+                finalTransform.getTransformation()
+            );
+        });
+    });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -26,6 +26,7 @@
     "no-suspicious-comment": false,
     "no-import-side-effect": false,
     "insecure-random": false,
+    "prefer-method-signature": false,
     "typedef": [
       true,
       "parameter",

--- a/tslint.json
+++ b/tslint.json
@@ -27,6 +27,7 @@
     "no-import-side-effect": false,
     "insecure-random": false,
     "prefer-method-signature": false,
+    "no-empty": false,
     "typedef": [
       true,
       "parameter",

--- a/tslint.json
+++ b/tslint.json
@@ -28,6 +28,7 @@
     "insecure-random": false,
     "prefer-method-signature": false,
     "no-empty": false,
+    "no-unnecessary-qualifier": false,
     "typedef": [
       true,
       "parameter",


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/50.

This lets you create animations:
```typescript
Animation.create({
    node: some_node,
    to: (node: Node) => {
        // some command that moves the node into a new position, as if you were posing it directly
    },
    start: Animation.now(),
    duration: 1000,
    times: 2,
    repeatDelay: 0
});
```

Future work:
- Add an API like `Animation.duration(3, 'seconds')` to avoid directly typing out milliseconds
- Add an API like `Animation.infinite()` instead of using `times: 0` to represent repeated animations
- Add callbacks so we can queue up other animations when current ones start/finish/cycle
- Add support for nonlinear interpolation
- Make interpolation more efficient (we generate a lot of intermediate vectors and matrices)

Updates to the example:
- The flailing sphere thing picks a new rotation target every second