### PR TITLE
Performance fix + Actually use REGL types

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "gl-matrix": "^2.5.1",
     "lodash": "^4.17.10",
-    "regl": "^1.3.1",
+    "regl": "regl-project/regl",
     "ts-sinon": "^1.0.12",
     "tslib": "~1.9.0"
   }

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -6,35 +6,37 @@ import { matrix4, vector3 } from '../types/VectorTypes';
 import { NodeRenderObject } from './NodeRenderObject';
 import { Transformation } from './Transformation';
 
+import { flatten, flatMap } from 'lodash';
+
 /**
  * A `Node` in a scene-graph.
  */
 export class Node {
-    private static boneVertices: vec3[] = [
-        vec3.fromValues(0, 0, 0),
-        vec3.fromValues(0.5, 0.1, 0),
-        vec3.fromValues(0.5, 0, -0.1),
-        vec3.fromValues(0.5, -0.1, 0),
-        vec3.fromValues(0.5, 0, 0.1),
-        vec3.fromValues(1, 0, 0)
+    private static boneVertices: number[][] = [
+        [0, 0, 0],
+        [0.5, 0.1, 0],
+        [0.5, 0, -0.1],
+        [0.5, -0.1, 0],
+        [0.5, 0, 0.1],
+        [1, 0, 0]
     ];
 
     private static bone: BakedGeometry = {
-        vertices: Node.boneVertices,
-        normals: [
-            vec3.fromValues(-1, 0, 0),
-            vec3.fromValues(0, 1, 0),
-            vec3.fromValues(0, 0, -1),
-            vec3.fromValues(0, -1, 0),
-            vec3.fromValues(0, 0, 1),
-            vec3.fromValues(1, 0, 0)
-        ],
-        indices: [0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1, 5, 2, 1, 5, 3, 2, 5, 4, 3, 5, 1, 4],
+        vertices: Float32Array.from(flatten(Node.boneVertices)),
+        normals: Float32Array.from(flatten([
+            [-1, 0, 0],
+            [0, 1, 0],
+            [0, 0, -1],
+            [0, -1, 0],
+            [0, 0, 1],
+            [1, 0, 0]
+        ])),
+        indices: Int16Array.from([0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1, 5, 2, 1, 5, 3, 2, 5, 4, 3, 5, 1, 4]),
 
         // Map x, y, z to r, g, b to give a sense of bone orientation
-        colors: Node.boneVertices.map((v: vec3) =>
-            vec3.fromValues(v[0], v[1] / 0.1 + 0.1, v[2] / 0.1 + 0.1)
-        )
+        colors: Float32Array.from(flatMap(Node.boneVertices, (v: number[]) =>
+            [v[0], v[1] / 0.1 + 0.1, v[2] / 0.1 + 0.1]
+        ))
     };
 
     public readonly children: Node[];

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -26,32 +26,18 @@ export class Node {
         normals: Float32Array.from(
             flatten([[-1, 0, 0], [0, 1, 0], [0, 0, -1], [0, -1, 0], [0, 0, 1], [1, 0, 0]])
         ),
-        indices: Int16Array.from([
-            0,
-            1,
-            2,
-            0,
-            2,
-            3,
-            0,
-            3,
-            4,
-            0,
-            4,
-            1,
-            5,
-            2,
-            1,
-            5,
-            3,
-            2,
-            5,
-            4,
-            3,
-            5,
-            1,
-            4
-        ]),
+        indices: Int16Array.from(
+            flatten([
+                [0, 1, 2],
+                [0, 2, 3],
+                [0, 3, 4],
+                [0, 4, 1],
+                [5, 2, 1],
+                [5, 3, 2],
+                [5, 4, 3],
+                [5, 1, 4]
+            ])
+        ),
 
         // Map x, y, z to r, g, b to give a sense of bone orientation
         colors: Float32Array.from(

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -23,20 +23,40 @@ export class Node {
 
     private static bone: BakedGeometry = {
         vertices: Float32Array.from(flatten(Node.boneVertices)),
-        normals: Float32Array.from(flatten([
-            [-1, 0, 0],
-            [0, 1, 0],
-            [0, 0, -1],
-            [0, -1, 0],
-            [0, 0, 1],
-            [1, 0, 0]
-        ])),
-        indices: Int16Array.from([0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1, 5, 2, 1, 5, 3, 2, 5, 4, 3, 5, 1, 4]),
+        normals: Float32Array.from(
+            flatten([[-1, 0, 0], [0, 1, 0], [0, 0, -1], [0, -1, 0], [0, 0, 1], [1, 0, 0]])
+        ),
+        indices: Int16Array.from([
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+            0,
+            3,
+            4,
+            0,
+            4,
+            1,
+            5,
+            2,
+            1,
+            5,
+            3,
+            2,
+            5,
+            4,
+            3,
+            5,
+            1,
+            4
+        ]),
 
         // Map x, y, z to r, g, b to give a sense of bone orientation
-        colors: Float32Array.from(flatMap(Node.boneVertices, (v: number[]) =>
-            [v[0], v[1] / 0.1 + 0.1, v[2] / 0.1 + 0.1]
-        ))
+        colors: Float32Array.from(
+            flatMap(Node.boneVertices, (v: number[]) => [v[0], v[1] / 0.1 + 0.1, v[2] / 0.1 + 0.1])
+        )
     };
 
     public readonly children: Node[];

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -5,7 +5,7 @@ import { Light } from '../renderer/interfaces/Light';
 import { Renderer } from '../renderer/Renderer';
 
 import { mat4, quat, vec3 } from 'gl-matrix';
-import { range } from 'lodash';
+import { flatMap, range } from 'lodash';
 import { Constraints } from '../armature/Constraints';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
@@ -22,7 +22,7 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-sphere.colors = sphere.vertices.map(() => vec3.fromValues(1, 0, 0));
+sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length/3), () => [1, 0, 0]));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -22,7 +22,7 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length/3), () => [1, 0, 0]));
+sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => [1, 0, 0]));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/geometry/BakedGeometry.ts
+++ b/src/geometry/BakedGeometry.ts
@@ -1,11 +1,9 @@
-import { vec3 } from 'gl-matrix';
-
 /**
  * After modelling is complete, a BakedGeometry should be returned for use in the renderer.
  */
 export type BakedGeometry = {
-    vertices: vec3[];
-    normals: vec3[];
-    indices: number[];
-    colors: vec3[];
+    vertices: Float32Array;
+    normals: Float32Array;
+    indices: Int16Array;
+    colors: Float32Array;
 };

--- a/src/geometry/Sphere.ts
+++ b/src/geometry/Sphere.ts
@@ -1,5 +1,5 @@
 import { vec3 } from 'gl-matrix';
-import { range } from 'lodash';
+import { flatMap, range } from 'lodash';
 
 import { BakedGeometry } from './BakedGeometry';
 import { genIsoSurface } from './MarchingCubes';
@@ -19,9 +19,9 @@ export function genSphere(): BakedGeometry {
     const vertices = genIsoSurface(sphere);
 
     return {
-        vertices: vertices,
-        normals: vertices,
-        indices: range(vertices.length),
-        colors: [] // colors are created by the caller
+        vertices: Float32Array.from(flatMap(vertices, (v: vec3) => [v[0], v[1], v[2]])),
+        normals: Float32Array.from(flatMap(vertices, (v: vec3) => [v[0], v[1], v[2]])),
+        indices: Int16Array.from(range(vertices.length)),
+        colors: Float32Array.from([]) // colors are created by the caller
     };
 }

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -85,9 +85,11 @@ export class WorkingGeometry {
     public bake(): BakedGeometry {
         this.combine();
 
-        const bakedVertices = this.vertices.map((workingVec: vec4) =>
-            [workingVec[0], workingVec[1], workingVec[2]]
-        );
+        const bakedVertices = this.vertices.map((workingVec: vec4) => [
+            workingVec[0],
+            workingVec[1],
+            workingVec[2]
+        ]);
         const bakedIndecies = this.faces.reduce((accum: number[], face: Face) => {
             return accum.concat(face.indices);
         }, []);

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -2,6 +2,8 @@ import { mat4, quat, vec3, vec4 } from 'gl-matrix';
 import { Affine } from '../utils/affine';
 import { BakedGeometry } from './BakedGeometry';
 
+import { flatten } from 'lodash';
+
 /**
  * A representation of a surface on an object.
  */
@@ -84,7 +86,7 @@ export class WorkingGeometry {
         this.combine();
 
         const bakedVertices = this.vertices.map((workingVec: vec4) =>
-            vec3.fromValues(workingVec[0], workingVec[1], workingVec[2])
+            [workingVec[0], workingVec[1], workingVec[2]]
         );
         const bakedIndecies = this.faces.reduce((accum: number[], face: Face) => {
             return accum.concat(face.indices);
@@ -96,17 +98,19 @@ export class WorkingGeometry {
             const v1: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p1, p2));
             const v2: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p2, p3));
 
-            return vec3.cross(vec3.create(), v1, v2);
+            const normal = vec3.cross(vec3.create(), v1, v2);
+
+            return [normal[0], normal[1], normal[2]];
         });
 
         // Make all of the baked shapes red for now.
-        const bakedColors: vec3[] = bakedVertices.map(() => vec3.fromValues(1, 0, 0));
+        const bakedColors = bakedVertices.map(() => [1, 0, 0]);
 
         return {
-            vertices: bakedVertices,
-            normals: bakedNormals,
-            indices: bakedIndecies,
-            colors: bakedColors
+            vertices: Float32Array.from(flatten(bakedVertices)),
+            normals: Float32Array.from(flatten(bakedNormals)),
+            indices: Int16Array.from(bakedIndecies),
+            colors: Float32Array.from(flatten(bakedColors))
         };
     }
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -14,8 +14,6 @@ import { Node } from '../armature/Node';
 import { DebugParams } from './interfaces/DebugParams';
 import { RenderParams } from './interfaces/RenderParams';
 
-// tslint:disable:no-unsafe-any
-
 /**
  * Manages all scene information and is responsible for rendering it to the screen
  */
@@ -230,7 +228,7 @@ export class Renderer {
         this.clearDepth();
 
         const [zero, x, y, z] = [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]].map(
-            (point: number[]) => {
+            (point: number[]): vec4 => {
                 // Initially treat these as vectors (w = 0) instead of points (where w would be 1)
                 // so that only the direction changes, and they are not translated from the origin
                 const vector = vec4.fromValues(point[0], point[1], point[2], 0);
@@ -252,15 +250,17 @@ export class Renderer {
         const redHex = '#FF0000';
         const greenHex = '#00FF00';
         const blueHex = '#0000FF';
-        const redRGB = [1, 0, 0]; // redHex
-        const greenRGB = [0, 1, 0]; // greenHex
-        const blueRGB = [0, 0, 1]; // blueHex
+        const redRGB = vec3.fromValues(1, 0, 0); // redHex
+        const greenRGB = vec3.fromValues(0, 1, 0); // greenHex
+        const blueRGB = vec3.fromValues(0, 0, 1); // blueHex
 
-        this.drawAxes({
-            positions: [zero, x, zero, y, zero, z],
-            colors: [redRGB, redRGB, greenRGB, greenRGB, blueRGB, blueRGB],
-            count: 6
-        });
+        this.drawAxes([
+            {
+                positions: [zero, x, zero, y, zero, z],
+                colors: [redRGB, redRGB, greenRGB, greenRGB, blueRGB, blueRGB],
+                count: 6
+            }
+        ]);
 
         // Use the 2D projected points to draw text labels for the axes. To convert the GL 3D point
         // to a point where each element is in [0, 1], we use:

--- a/src/renderer/commands/createDrawAxes.ts
+++ b/src/renderer/commands/createDrawAxes.ts
@@ -1,19 +1,20 @@
+import { vec3, vec4 } from 'gl-matrix';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
 
 // tslint:disable:no-unsafe-any
 
 interface Attributes {
-    position: REGL.Vec3;
-    color: REGL.Vec3;
+    position: vec3;
+    color: vec3;
 }
 
 /*
  * All the information needed to be able to draw axes to the screen
  */
 export interface DrawAxesProps {
-    positions: REGL.Vec4[];
-    colors: REGL.Vec3[];
+    positions: vec4[];
+    colors: vec3[];
     count: number;
 }
 
@@ -48,10 +49,10 @@ export function createDrawAxes(
         `,
         primitive: 'lines',
         attributes: {
-            position: regl.prop('positions'),
-            color: regl.prop('colors')
+            position: regl.prop<DrawAxesProps, keyof DrawAxesProps>('positions'),
+            color: regl.prop<DrawAxesProps, keyof DrawAxesProps>('colors')
         },
         uniforms: {},
-        count: regl.prop('count')
+        count: regl.prop<DrawAxesProps, keyof DrawAxesProps>('count')
     });
 }

--- a/src/renderer/commands/createDrawAxes.ts
+++ b/src/renderer/commands/createDrawAxes.ts
@@ -2,8 +2,6 @@ import { vec3, vec4 } from 'gl-matrix';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
 
-// tslint:disable:no-unsafe-any
-
 interface Attributes {
     position: vec3;
     color: vec3;

--- a/src/renderer/commands/createDrawObject.ts
+++ b/src/renderer/commands/createDrawObject.ts
@@ -1,5 +1,6 @@
 import { blankLight, Light } from '../interfaces/Light';
 
+import { mat4, vec3 } from 'gl-matrix';
 import { range } from 'lodash';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
@@ -8,36 +9,36 @@ import REGL = require('regl');
 
 // Uniforms are the same for all vertices.
 interface Uniforms {
-    projection: REGL.Mat4;
-    view: REGL.Mat4;
-    model: REGL.Mat4;
+    projection: mat4;
+    view: mat4;
+    model: mat4;
     numLights: number;
-    ambientLight: REGL.Vec3;
-    lightPositions: REGL.Vec3[];
-    lightColors: REGL.Vec3[];
-    lightIntensities: number[];
+    ambientLight: vec3;
     isShadeless: boolean;
 }
 
 // Attributes are per vertex.
 interface Attributes {
-    position: REGL.Vec3;
-    normal: REGL.Vec3;
-    color: REGL.Vec3;
+    position: vec3;
+    normal: vec3;
+    color: vec3;
 }
 
 /**
  * All the information needed to be able to draw an object to the screen
  */
 export interface DrawObjectProps {
-    model: REGL.Mat4;
-    cameraTransform: REGL.Mat4;
-    projectionMatrix: REGL.Mat4;
-    positions: REGL.Vec3[];
-    normals: REGL.Vec3[];
-    colors: REGL.Vec3[];
+    model: mat4;
+    cameraTransform: mat4;
+    projectionMatrix: mat4;
+    positions: vec3[];
+    normals: vec3[];
+    colors: vec3[];
     indices: number[];
+    numLights: number;
+    ambientLight: vec3;
     isShadeless: boolean;
+    lights: Light[];
 }
 
 /**
@@ -46,7 +47,7 @@ export interface DrawObjectProps {
  * @param {REGL.regl} regl The regl object factory to build a function to draw an object.
  */
 export function createDrawObject(
-    regl: REGL.regl,
+    regl: REGL.Regl,
     maxLights: number
 ): REGL.DrawCommand<REGL.DefaultContext, DrawObjectProps> {
     return regl<Uniforms, Attributes, DrawObjectProps>({
@@ -120,20 +121,20 @@ export function createDrawObject(
             }
         `,
         attributes: {
-            position: regl.prop('positions'),
-            normal: regl.prop('normals'),
-            color: regl.prop('colors')
+            position: regl.prop<DrawObjectProps, keyof DrawObjectProps>('positions'),
+            normal: regl.prop<DrawObjectProps, keyof DrawObjectProps>('normals'),
+            color: regl.prop<DrawObjectProps, keyof DrawObjectProps>('colors')
         },
         uniforms: {
-            projection: regl.prop('projectionMatrix'),
-            view: regl.prop('cameraTransform'),
-            model: regl.prop('model'),
-            numLights: regl.prop('numLights'),
-            ambientLight: regl.prop('ambientLight'),
-            isShadeless: regl.prop('isShadeless'),
+            projection: regl.prop<DrawObjectProps, keyof DrawObjectProps>('projectionMatrix'),
+            view: regl.prop<DrawObjectProps, keyof DrawObjectProps>('cameraTransform'),
+            model: regl.prop<DrawObjectProps, keyof DrawObjectProps>('model'),
+            numLights: regl.prop<DrawObjectProps, keyof DrawObjectProps>('numLights'),
+            ambientLight: regl.prop<DrawObjectProps, keyof DrawObjectProps>('ambientLight'),
+            isShadeless: regl.prop<DrawObjectProps, keyof DrawObjectProps>('isShadeless'),
             ...buildLightMetadata(maxLights)
         },
-        elements: regl.prop('indices')
+        elements: regl.prop<DrawObjectProps, keyof DrawObjectProps>('indices')
     });
 }
 

--- a/src/renderer/commands/createDrawObject.ts
+++ b/src/renderer/commands/createDrawObject.ts
@@ -19,9 +19,9 @@ interface Uniforms {
 
 // Attributes are per vertex.
 interface Attributes {
-    position: vec3;
-    normal: vec3;
-    color: vec3;
+    position: Float32Array;
+    normal: Float32Array;
+    color: Float32Array;
 }
 
 /**
@@ -31,10 +31,10 @@ export interface DrawObjectProps {
     model: mat4;
     cameraTransform: mat4;
     projectionMatrix: mat4;
-    positions: vec3[];
-    normals: vec3[];
-    colors: vec3[];
-    indices: number[];
+    positions: Float32Array;
+    normals: Float32Array;
+    colors: Float32Array;
+    indices: Int16Array;
     numLights: number;
     ambientLight: vec3;
     isShadeless: boolean;

--- a/src/renderer/interfaces/Light.ts
+++ b/src/renderer/interfaces/Light.ts
@@ -2,8 +2,8 @@
 import REGL = require('regl');
 
 export interface Light {
-    lightPosition: REGL.Vec3[];
-    lightColor: REGL.Vec3[];
+    lightPosition: REGL.Vec3;
+    lightColor: REGL.Vec3;
     lightIntensity: number;
 }
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -145,7 +145,7 @@ describe('Node', () => {
     describe('attach', () => {
         it('creates a GeometryNode for the attached geometry', () => {
             const parent = bone();
-            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
 
             parent.point('tip').attach(geometry);
             expect(parent.children.length).toBe(1);
@@ -371,7 +371,7 @@ describe('Node', () => {
 
     describe('traverse', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
-            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
@@ -406,7 +406,7 @@ describe('Node', () => {
         });
 
         it('defaults to no transformation', () => {
-            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
@@ -434,7 +434,7 @@ describe('Node', () => {
         });
 
         it('shows bones when asked', () => {
-            const geometry: BakedGeometry = { vertices: [], normals: [], indices: [], colors: [] };
+            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
             const geometryChild = new GeometryNode(geometry);
             const root = new Node([geometryChild]);
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -145,7 +145,12 @@ describe('Node', () => {
     describe('attach', () => {
         it('creates a GeometryNode for the attached geometry', () => {
             const parent = bone();
-            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
+            const geometry: BakedGeometry = {
+                vertices: Float32Array.from([]),
+                normals: Float32Array.from([]),
+                indices: Int16Array.from([]),
+                colors: Float32Array.from([])
+            };
 
             parent.point('tip').attach(geometry);
             expect(parent.children.length).toBe(1);
@@ -371,7 +376,12 @@ describe('Node', () => {
 
     describe('traverse', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
-            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
+            const geometry: BakedGeometry = {
+                vertices: Float32Array.from([]),
+                normals: Float32Array.from([]),
+                indices: Int16Array.from([]),
+                colors: Float32Array.from([])
+            };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
@@ -406,7 +416,12 @@ describe('Node', () => {
         });
 
         it('defaults to no transformation', () => {
-            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
+            const geometry: BakedGeometry = {
+                vertices: Float32Array.from([]),
+                normals: Float32Array.from([]),
+                indices: Int16Array.from([]),
+                colors: Float32Array.from([])
+            };
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
@@ -434,7 +449,12 @@ describe('Node', () => {
         });
 
         it('shows bones when asked', () => {
-            const geometry: BakedGeometry = { vertices: Float32Array.from([]), normals: Float32Array.from([]), indices: Int16Array.from([]), colors: Float32Array.from([]) };
+            const geometry: BakedGeometry = {
+                vertices: Float32Array.from([]),
+                normals: Float32Array.from([]),
+                indices: Int16Array.from([]),
+                colors: Float32Array.from([])
+            };
             const geometryChild = new GeometryNode(geometry);
             const root = new Node([geometryChild]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5609,9 +5609,9 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-regl@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regl/-/regl-1.3.1.tgz#2995e63a7984c520ef2da0f6f1027f7051338140"
+regl@regl-project/regl:
+  version "1.3.6"
+  resolved "https://codeload.github.com/regl-project/regl/tar.gz/3dc66c5d52771e79562bbf28818250329c8f422e"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/63

**NOTE: YOU WILL NEED TO `yarn install` AGAIN AFTER THIS IS MERGED.**

This uses the regl git repo instead of regl on npm, since typescript bindings havent been put into an npm release yet. Renderer changes will now be typechecked!

## Performance fix
All of the time was spent flattening arrays and copying values into buffers. By using a typed array (`Float32Array` and `Int16Array`) directly instead of a `vec3[]`, the performance went from this:
<img width="259" alt="screen shot 2018-06-06 at 6 54 12 pm" src="https://user-images.githubusercontent.com/5315059/41069240-07bd0586-69bb-11e8-8a09-33de6c1322bb.png">

to this:
<img width="169" alt="screen shot 2018-06-06 at 6 50 49 pm" src="https://user-images.githubusercontent.com/5315059/41069205-e105b280-69ba-11e8-9bb7-b16a4fa8d569.png">