### PR TITLE
Add vertex normals

### DIFF
--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -152,48 +152,6 @@ export class WorkingGeometry {
     }
 
     /**
-     * Stretch from the pull point to the destination direction by the given
-     * factor, while allowing shearing.
-     *
-     * @param {vec3} pullPoint: the point being pulled away from the origin.
-     * @param {number} destDir: the direction away from the origin that
-     * pullPoint is being pulled to.
-     * @param {vec3} factor: the scaling factor.
-     */
-    private freeformStretch(pullPoint: vec3, destDir: vec3, factor: number) {
-        const rotPullToXAxis = mat4.fromQuat(
-            mat4.create(),
-            quat.rotationTo(
-                quat.create(),
-                vec3.normalize(vec3.create(), pullPoint),
-                vec3.fromValues(1, 0, 0)
-            )
-        );
-
-        const scalePullByFactorOnXAxis = mat4.scale(
-            mat4.create(),
-            mat4.create(),
-            vec3.fromValues(factor, 1, 1)
-        );
-
-        const rotXAxisToDestAxis = mat4.fromQuat(
-            mat4.create(),
-            quat.rotationTo(
-                quat.create(),
-                vec3.fromValues(1, 0, 0),
-                vec3.normalize(vec3.create(), destDir)
-            )
-        );
-
-        // Assemble all the matrices!
-        const matrix = rotXAxisToDestAxis;
-        mat4.mul(matrix, matrix, scalePullByFactorOnXAxis);
-        mat4.mul(matrix, matrix, rotPullToXAxis);
-
-        this.transform(matrix);
-    }
-
-    /**
      * Scale by pulling a point to a new point.
      *
      * @param {vec3} pullPoint: point that scales to destinationPoint after transformation.
@@ -309,5 +267,47 @@ export class WorkingGeometry {
         this.normals = this.normals.map((workingVec: vec4) =>
             vec4.transformMat4(vec4.create(), workingVec, normalMat)
         );
+    }
+
+    /**
+     * Stretch from the pull point to the destination direction by the given
+     * factor, while allowing shearing.
+     *
+     * @param {vec3} pullPoint: the point being pulled away from the origin.
+     * @param {number} destDir: the direction away from the origin that
+     * pullPoint is being pulled to.
+     * @param {vec3} factor: the scaling factor.
+     */
+    private freeformStretch(pullPoint: vec3, destDir: vec3, factor: number) {
+        const rotPullToXAxis = mat4.fromQuat(
+            mat4.create(),
+            quat.rotationTo(
+                quat.create(),
+                vec3.normalize(vec3.create(), pullPoint),
+                vec3.fromValues(1, 0, 0)
+            )
+        );
+
+        const scalePullByFactorOnXAxis = mat4.scale(
+            mat4.create(),
+            mat4.create(),
+            vec3.fromValues(factor, 1, 1)
+        );
+
+        const rotXAxisToDestAxis = mat4.fromQuat(
+            mat4.create(),
+            quat.rotationTo(
+                quat.create(),
+                vec3.fromValues(1, 0, 0),
+                vec3.normalize(vec3.create(), destDir)
+            )
+        );
+
+        // Assemble all the matrices!
+        const matrix = rotXAxisToDestAxis;
+        mat4.mul(matrix, matrix, scalePullByFactorOnXAxis);
+        mat4.mul(matrix, matrix, rotPullToXAxis);
+
+        this.transform(matrix);
     }
 }

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -15,12 +15,10 @@ export class Face {
     public indices: number[];
 
     /**
-     * @param {number[]} indices: Reference indeces of vertices in a WorkingGeometry.
-     * @param {vec4} normal: A fector representing the direction out of the face.
+     * @param {number[]} indices: Reference indices of vertices in a WorkingGeometry.
      * @return {Face}
      */
     constructor(indices: number[]) {
-        // TODO(pbardea): Verify length of indices here.
         this.indices = indices;
     }
 }
@@ -36,8 +34,14 @@ export class WorkingGeometry {
     public vertices: vec4[];
 
     /**
-     * The surfaces of the object. Each face includes the indices of the vertices that make up the
-     * surface's polygon.
+     * The normals that correspond to the vertices. For each normal n, n[3] must be equal to 1 to
+     * ensure that it is a vector.
+     */
+    public normals: vec4[];
+
+    /**
+     * The surfaces of the object. Each face includes the indices of the vertices and normals that
+     * make up the surface's polygon. Note that vertices and normals use the same buffer.
      */
     public faces: Face[];
 
@@ -56,13 +60,15 @@ export class WorkingGeometry {
      * Creates a working geometry from a given set of vertices, faces, and control points.
      *
      * @param {vec3[]} vertices: The points that make up the geometry.
+     * @param {vec3[]} normals: The normals corresponding to the vertices.
      * @param {Face[]} faces: The surfaces of the object, relating the vertices to each other.
      * @param {vec3[]} controlPoints: A set of points to snap to or reference.
      * @return {WorkingGeometry}
      */
-    constructor(vertices: vec3[] = [], faces: Face[] = [], controlPoints: vec3[] = []) {
-        // TODO(pbardea): Check if max(indecies) of all faces is <= the len(vertices)
+    constructor(vertices: vec3[] = [], normals: vec3[] = [], faces: Face[] = [], controlPoints: vec3[] = []) {
+        // TODO(pbardea): Check if max(indices) of all faces is <= the len(vertices)
         this.vertices = vertices.map(Affine.createPoint);
+        this.normals = normals.map(Affine.createVector);
         this.faces = faces;
         this.controlPoints = controlPoints.map(Affine.createPoint);
         this.mergedObjects = [];
@@ -90,20 +96,14 @@ export class WorkingGeometry {
             workingVec[1],
             workingVec[2]
         ]);
-        const bakedIndecies = this.faces.reduce((accum: number[], face: Face) => {
+        const bakedIndices = this.faces.reduce((accum: number[], face: Face) => {
             return accum.concat(face.indices);
         }, []);
-        const bakedNormals = this.faces.map((face: Face) => {
-            const p1: vec4 = this.vertices[face.indices[0]];
-            const p2: vec4 = this.vertices[face.indices[1]];
-            const p3: vec4 = this.vertices[face.indices[2]];
-            const v1: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p1, p2));
-            const v2: vec3 = Affine.to3D(vec4.subtract(vec4.create(), p2, p3));
-
-            const normal = vec3.cross(vec3.create(), v1, v2);
-
-            return [normal[0], normal[1], normal[2]];
-        });
+        const bakedNormals = this.normals.map((workingVec: vec4) => [
+            workingVec[0],
+            workingVec[1],
+            workingVec[2]
+        ]);
 
         // Make all of the baked shapes red for now.
         const bakedColors = bakedVertices.map(() => [1, 0, 0]);
@@ -111,7 +111,7 @@ export class WorkingGeometry {
         return {
             vertices: Float32Array.from(flatten(bakedVertices)),
             normals: Float32Array.from(flatten(bakedNormals)),
-            indices: Int16Array.from(bakedIndecies),
+            indices: Int16Array.from(bakedIndices),
             colors: Float32Array.from(flatten(bakedColors))
         };
     }
@@ -149,22 +149,34 @@ export class WorkingGeometry {
     /**
      * Scale by pulling a point to a new point.
      *
-     * @param {vec3} pullPoint: point that scales to destination_point after transformation.
-     * @param {vec3} destinationPoint: point that is the result of pull_point after transformation.
+     * @param {vec3} pullPoint: point that scales to destinationPoint after transformation.
+     * @param {vec3} destinationPoint: point that is the result of pullPoint after transformation.
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
     public scale(pullPoint: vec3, destinationPoint: vec3, holdPoint: vec3 = vec3.create()) {
-        const destinationVector: vec3 = vec3.sub(vec3.create(), destinationPoint, holdPoint);
-        const pullVector: vec3 = vec3.sub(vec3.create(), pullPoint, holdPoint);
-        const scalingVector: vec3 = this.getScalingVector(destinationVector, pullVector);
-        const scalingMatrix: mat4 = mat4.fromRotationTranslationScaleOrigin(
-            mat4.create(),
-            quat.create(),
-            vec3.create(),
-            scalingVector,
-            holdPoint
-        );
-        this.transform(scalingMatrix);
+      const moveHoldToOrigin = mat4.translate(
+        mat4.create(), mat4.create(),
+        vec3.negate(vec3.create(), holdPoint));
+
+      const translatedPullPoint = vec3.sub(vec3.create(), pullPoint, holdPoint);
+      const translatedDestinationPoint = vec3.sub(vec3.create(), destinationPoint, holdPoint);
+
+      const rotPullToXAxis = mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), vec3.normalize(vec3.create(), translatedPullPoint), vec3.fromValues(1, 0, 0)));
+
+      const scalePullToDestOnXAxis = mat4.scale(mat4.create(), mat4.create(), vec3.fromValues(vec3.len(translatedDestinationPoint) / vec3.len(translatedPullPoint), 1, 1));
+
+      const rotXAxisToDestAxis = mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), vec3.fromValues(1, 0, 0), vec3.normalize(vec3.create(), translatedDestinationPoint)));
+
+      const moveOriginToHold = mat4.translate(mat4.create(), mat4.create(), holdPoint);
+
+      // Assemble all the matrices!
+      let matrix = moveOriginToHold;
+      mat4.mul(matrix, matrix, rotXAxisToDestAxis);
+      mat4.mul(matrix, matrix, scalePullToDestOnXAxis);
+      mat4.mul(matrix, matrix, rotPullToXAxis);
+      mat4.mul(matrix, matrix, moveHoldToOrigin);
+
+      this.transform(matrix);
     }
 
     /**
@@ -175,19 +187,12 @@ export class WorkingGeometry {
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
     public scaleByFactor(factor: number, pullPoint: vec3, holdPoint: vec3 = vec3.create()) {
-        const scalingDirection: vec3 = vec3.sub(vec3.create(), pullPoint, holdPoint);
-        const absScalingDirection: vec3 = vec3.fromValues(
-            Math.abs(scalingDirection[0]),
-            Math.abs(scalingDirection[1]),
-            Math.abs(scalingDirection[2])
-        );
         const factorVector: vec3 = vec3.fromValues(factor, factor, factor);
-        const scalingVector: vec3 = vec3.mul(vec3.create(), absScalingDirection, factorVector);
         const scalingMatrix: mat4 = mat4.fromRotationTranslationScaleOrigin(
             mat4.create(),
             quat.create(),
             vec3.create(),
-            scalingVector,
+            factorVector,
             holdPoint
         );
         this.transform(scalingMatrix);
@@ -204,6 +209,7 @@ export class WorkingGeometry {
         let vertexCount = this.vertices.length;
         for (const child of this.mergedObjects) {
             this.vertices = this.vertices.concat(child.vertices);
+            this.normals = this.normals.concat(child.normals);
             child.faces.forEach((face: Face) => {
                 const newIndices = face.indices.map((i: number) => i + vertexCount);
                 face.indices = newIndices;
@@ -278,6 +284,14 @@ export class WorkingGeometry {
     private transform(matrix: mat4) {
         this.vertices = this.vertices.map((workingVec: vec4) =>
             vec4.transformMat4(vec4.create(), workingVec, matrix)
+        );
+        let inv = mat4.invert(mat4.create(), matrix);
+        if (inv === null) {
+            throw new Error('Uninvertible transformation matrix');
+        }
+        let normalMat = mat4.transpose(mat4.create(), inv);
+        this.normals = this.normals.map((workingVec: vec4) =>
+            vec4.transformMat4(vec4.create(), workingVec, normalMat)
         );
     }
 }

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -158,7 +158,7 @@ export class WorkingGeometry {
      * @param {vec3} destinationPoint: point that is the result of pullPoint after transformation.
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
-    public scale(pullPoint: vec3, destinationPoint: vec3, holdPoint: vec3 = vec3.create()) {
+    public freeformStretchTo(pullPoint: vec3, destinationPoint: vec3, holdPoint: vec3 = vec3.create()) {
         const moveHoldToOrigin = mat4.translate(
             mat4.create(),
             mat4.create(),
@@ -199,8 +199,6 @@ export class WorkingGeometry {
         const moveOriginToHold = mat4.translate(mat4.create(), mat4.create(), holdPoint);
 
         // Assemble all the matrices!
-        // Note that matrix is modified after each mul call, but the linter can't figure that out,
-        // so the const is only there to appease the linter
         const matrix = moveOriginToHold;
         mat4.mul(matrix, matrix, rotXAxisToDestAxis);
         mat4.mul(matrix, matrix, scalePullToDestOnXAxis);
@@ -211,13 +209,12 @@ export class WorkingGeometry {
     }
 
     /**
-     * Scale by a given factor between 2 points.
+     * Scale by a given factor away from a given point.
      *
      * @param {number} factor: scaling factor.
-     * @param {vec3} pullPoint: point that will be scaled by factor away from holdPoint.
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
-    public scaleByFactor(factor: number, holdPoint: vec3 = vec3.create()) {
+    public proportionalStretchTo(factor: number, holdPoint: vec3 = vec3.create()) {
         const factorVector: vec3 = vec3.fromValues(factor, factor, factor);
         const scalingMatrix: mat4 = mat4.fromRotationTranslationScaleOrigin(
             mat4.create(),

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -65,7 +65,12 @@ export class WorkingGeometry {
      * @param {vec3[]} controlPoints: A set of points to snap to or reference.
      * @return {WorkingGeometry}
      */
-    constructor(vertices: vec3[] = [], normals: vec3[] = [], faces: Face[] = [], controlPoints: vec3[] = []) {
+    constructor(
+        vertices: vec3[] = [],
+        normals: vec3[] = [],
+        faces: Face[] = [],
+        controlPoints: vec3[] = []
+    ) {
         // TODO(pbardea): Check if max(indices) of all faces is <= the len(vertices)
         this.vertices = vertices.map(Affine.createPoint);
         this.normals = normals.map(Affine.createVector);
@@ -154,29 +159,53 @@ export class WorkingGeometry {
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
     public scale(pullPoint: vec3, destinationPoint: vec3, holdPoint: vec3 = vec3.create()) {
-      const moveHoldToOrigin = mat4.translate(
-        mat4.create(), mat4.create(),
-        vec3.negate(vec3.create(), holdPoint));
+        const moveHoldToOrigin = mat4.translate(
+            mat4.create(),
+            mat4.create(),
+            vec3.negate(vec3.create(), holdPoint)
+        );
 
-      const translatedPullPoint = vec3.sub(vec3.create(), pullPoint, holdPoint);
-      const translatedDestinationPoint = vec3.sub(vec3.create(), destinationPoint, holdPoint);
+        const translatedPullPoint = vec3.sub(vec3.create(), pullPoint, holdPoint);
+        const translatedDestinationPoint = vec3.sub(vec3.create(), destinationPoint, holdPoint);
 
-      const rotPullToXAxis = mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), vec3.normalize(vec3.create(), translatedPullPoint), vec3.fromValues(1, 0, 0)));
+        const rotPullToXAxis = mat4.fromQuat(
+            mat4.create(),
+            quat.rotationTo(
+                quat.create(),
+                vec3.normalize(vec3.create(), translatedPullPoint),
+                vec3.fromValues(1, 0, 0)
+            )
+        );
 
-      const scalePullToDestOnXAxis = mat4.scale(mat4.create(), mat4.create(), vec3.fromValues(vec3.len(translatedDestinationPoint) / vec3.len(translatedPullPoint), 1, 1));
+        const scalePullToDestOnXAxis = mat4.scale(
+            mat4.create(),
+            mat4.create(),
+            vec3.fromValues(
+                vec3.len(translatedDestinationPoint) / vec3.len(translatedPullPoint),
+                1,
+                1
+            )
+        );
 
-      const rotXAxisToDestAxis = mat4.fromQuat(mat4.create(), quat.rotationTo(quat.create(), vec3.fromValues(1, 0, 0), vec3.normalize(vec3.create(), translatedDestinationPoint)));
+        const rotXAxisToDestAxis = mat4.fromQuat(
+            mat4.create(),
+            quat.rotationTo(
+                quat.create(),
+                vec3.fromValues(1, 0, 0),
+                vec3.normalize(vec3.create(), translatedDestinationPoint)
+            )
+        );
 
-      const moveOriginToHold = mat4.translate(mat4.create(), mat4.create(), holdPoint);
+        const moveOriginToHold = mat4.translate(mat4.create(), mat4.create(), holdPoint);
 
-      // Assemble all the matrices!
-      let matrix = moveOriginToHold;
-      mat4.mul(matrix, matrix, rotXAxisToDestAxis);
-      mat4.mul(matrix, matrix, scalePullToDestOnXAxis);
-      mat4.mul(matrix, matrix, rotPullToXAxis);
-      mat4.mul(matrix, matrix, moveHoldToOrigin);
+        // Assemble all the matrices!
+        let matrix = moveOriginToHold;
+        mat4.mul(matrix, matrix, rotXAxisToDestAxis);
+        mat4.mul(matrix, matrix, scalePullToDestOnXAxis);
+        mat4.mul(matrix, matrix, rotPullToXAxis);
+        mat4.mul(matrix, matrix, moveHoldToOrigin);
 
-      this.transform(matrix);
+        this.transform(matrix);
     }
 
     /**

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -158,7 +158,11 @@ export class WorkingGeometry {
      * @param {vec3} destinationPoint: point that is the result of pullPoint after transformation.
      * @param {vec3} holdPoint: point to scale from, default to true origin.
      */
-    public freeformStretchTo(pullPoint: vec3, destinationPoint: vec3, holdPoint: vec3 = vec3.create()) {
+    public freeformStretchTo(
+        pullPoint: vec3,
+        destinationPoint: vec3,
+        holdPoint: vec3 = vec3.create()
+    ) {
         const moveHoldToOrigin = mat4.translate(
             mat4.create(),
             mat4.create(),

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -370,10 +370,10 @@ describe('WorkingGeometry', () => {
         });
     });
     describe('scaleByFactor', () => {
-        it('can scale by a factor of 2 on the positive axes about origin', () => {
+        it('can scale by a factor of 2 about origin', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(2, vec3.fromValues(1, 1, 0));
+            square.scaleByFactor(2);
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(0, 0, 0, 1),
@@ -382,10 +382,10 @@ describe('WorkingGeometry', () => {
                 vec4.fromValues(2, 0, 0, 1)
             ]);
         });
-        it('can scale by a factor of 2 on the negative axes about (1, 1, 0)', () => {
+        it('can scale by a factor of 2 about (1, 1, 0)', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(2, vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 0));
+            square.scaleByFactor(2, vec3.fromValues(1, 1, 0));
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(-1, -1, 0, 1),
@@ -397,7 +397,7 @@ describe('WorkingGeometry', () => {
         it('can scale by a factor of 1 and remain unchanged', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(1, vec3.fromValues(1, 1, 0));
+            square.scaleByFactor(1);
 
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -320,11 +320,11 @@ describe('WorkingGeometry', () => {
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });
     });
-    describe('scale', () => {
+    describe('freeformStretchTo', () => {
         it('can scale from (1, 1, 0) to (2, 2, 0) about origin', () => {
             const square = TestHelper.square();
 
-            square.scale(vec3.fromValues(1, 1, 0), vec3.fromValues(2, 2, 0));
+            square.freeformStretchTo(vec3.fromValues(1, 1, 0), vec3.fromValues(2, 2, 0));
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(0, 0, 0, 1),
@@ -336,7 +336,7 @@ describe('WorkingGeometry', () => {
         it('can scale from (0, 0, 0) to (-1, -1, 0) about (1, 1, 0)', () => {
             const square = TestHelper.square();
 
-            square.scale(
+            square.freeformStretchTo(
                 vec3.fromValues(0, 0, 0),
                 vec3.fromValues(-1, -1, 0),
                 vec3.fromValues(1, 1, 0)
@@ -352,14 +352,14 @@ describe('WorkingGeometry', () => {
         it('can scale to itself and remain unchanged', () => {
             const square = TestHelper.square();
 
-            square.scale(vec3.fromValues(1, 1, 0), vec3.fromValues(1, 1, 0));
+            square.freeformStretchTo(vec3.fromValues(1, 1, 0), vec3.fromValues(1, 1, 0));
 
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });
         it('will perform a rotation when the pull and destination points are not colinear', () => {
             const square = TestHelper.square();
 
-            square.scale(vec3.create(), vec3.fromValues(1, 1, 0), vec3.fromValues(1, 0, 0));
+            square.freeformStretchTo(vec3.create(), vec3.fromValues(1, 1, 0), vec3.fromValues(1, 0, 0));
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(1, 1, 0, 1),
@@ -369,11 +369,11 @@ describe('WorkingGeometry', () => {
             ]);
         });
     });
-    describe('scaleByFactor', () => {
+    describe('proportionalStretchTo', () => {
         it('can scale by a factor of 2 about origin', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(2);
+            square.proportionalStretchTo(2);
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(0, 0, 0, 1),
@@ -385,7 +385,7 @@ describe('WorkingGeometry', () => {
         it('can scale by a factor of 2 about (1, 1, 0)', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(2, vec3.fromValues(1, 1, 0));
+            square.proportionalStretchTo(2, vec3.fromValues(1, 1, 0));
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(-1, -1, 0, 1),
@@ -397,7 +397,7 @@ describe('WorkingGeometry', () => {
         it('can scale by a factor of 1 and remain unchanged', () => {
             const square = TestHelper.square();
 
-            square.scaleByFactor(1);
+            square.proportionalStretchTo(1);
 
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -2,7 +2,7 @@ import { Face, WorkingGeometry } from '../../src/geometry/WorkingGeometry';
 import { TestHelper } from '../utils/helper';
 
 import { vec3, vec4 } from 'gl-matrix';
-import { flatten, range } from 'lodash';
+import { flatten, flatMap } from 'lodash';
 
 import '../glMatrix';
 
@@ -81,15 +81,14 @@ describe('WorkingGeometry', () => {
             const bakedSquare = square.bake();
 
             // Not testing the colors yet since they don't do anything useful
-            const expectedNormal = [0, 0, -1];
             expect(bakedSquare.indices).toEqual(Int16Array.from([0, 1, 2, 0, 2, 3]));
             compareFloatArrays(
                 bakedSquare.vertices,
-                Float32Array.from(vertices)
+                Float32Array.from(flatMap(vertices, (v: vec3) => [v[0], v[1], v[2]]))
             );
             compareFloatArrays(
                 bakedSquare.normals,
-                Float32Array.from(normals)
+                Float32Array.from(flatMap(normals, (n: vec3) => [n[0], n[1], n[2]]))
             );
         });
         it('can bake a WorkingGeometry that has many merged objects', () => {
@@ -153,11 +152,29 @@ describe('WorkingGeometry', () => {
                     ])
                 )
             );
-            // Normals should be an array of 8 (indices/3) [0, 0, 1] vectors
-            const indexStride = 3;
-            const normalCount = bakedObject.indices.length / indexStride;
-            const expectedNormals = range(normalCount).map(() => [0, 0, -1]);
-            compareFloatArrays(bakedObject.normals, Float32Array.from(flatten(expectedNormals)));
+            compareFloatArrays(
+                bakedObject.normals,
+                Float32Array.from(
+                    flatten([
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1],
+                        [0, 0, -1]
+                    ])
+                )
+            );
         });
     });
     describe('merge', () => {
@@ -359,7 +376,11 @@ describe('WorkingGeometry', () => {
         it('will perform a rotation when the pull and destination points are not colinear', () => {
             const square = TestHelper.square();
 
-            square.freeformStretchTo(vec3.create(), vec3.fromValues(1, 1, 0), vec3.fromValues(1, 0, 0));
+            square.freeformStretchTo(
+                vec3.create(),
+                vec3.fromValues(1, 1, 0),
+                vec3.fromValues(1, 0, 0)
+            );
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(1, 1, 0, 1),

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -45,7 +45,7 @@ describe('WorkingGeometry', () => {
                 vec3.fromValues(0, 0, -1),
                 vec3.fromValues(0, 0, -1),
                 vec3.fromValues(0, 0, -1),
-                vec3.fromValues(0, 0, -1),
+                vec3.fromValues(0, 0, -1)
             ];
             const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
@@ -73,7 +73,7 @@ describe('WorkingGeometry', () => {
                 vec3.fromValues(0, 0, -1),
                 vec3.fromValues(0, 0, -1),
                 vec3.fromValues(0, 0, -1),
-                vec3.fromValues(0, 0, -1),
+                vec3.fromValues(0, 0, -1)
             ];
             const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
@@ -336,10 +336,11 @@ describe('WorkingGeometry', () => {
         it('can scale from (0, 0, 0) to (-1, -1, 0) about (1, 1, 0)', () => {
             const square = TestHelper.square();
 
-          square.scale(
-            vec3.fromValues(0, 0, 0),
-            vec3.fromValues(-1, -1, 0),
-            vec3.fromValues(1, 1, 0));
+            square.scale(
+                vec3.fromValues(0, 0, 0),
+                vec3.fromValues(-1, -1, 0),
+                vec3.fromValues(1, 1, 0)
+            );
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(-1, -1, 0, 1),
@@ -360,12 +361,12 @@ describe('WorkingGeometry', () => {
 
             square.scale(vec3.create(), vec3.fromValues(1, 1, 0), vec3.fromValues(1, 0, 0));
 
-          expect(square.vertices).toEqualArrVec4([
-            vec4.fromValues(1, 1, 0, 1),
-            vec4.fromValues(2, 1, 0, 1),
-            vec4.fromValues(2, 0, 0, 1),
-            vec4.fromValues(1, 0, 0, 1),
-          ]);
+            expect(square.vertices).toEqualArrVec4([
+                vec4.fromValues(1, 1, 0, 1),
+                vec4.fromValues(2, 1, 0, 1),
+                vec4.fromValues(2, 0, 0, 1),
+                vec4.fromValues(1, 0, 0, 1)
+            ]);
         });
     });
     describe('scaleByFactor', () => {

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -373,7 +373,7 @@ describe('WorkingGeometry', () => {
 
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });
-        it('will perform a rotation when the pull and destination points are not colinear', () => {
+        it('will perform a rotation when the pull and destination points are not collinear', () => {
             const square = TestHelper.square();
 
             square.freeformStretchTo(
@@ -390,11 +390,11 @@ describe('WorkingGeometry', () => {
             ]);
         });
     });
-    describe('proportionalStretchTo', () => {
+    describe('proportionalStretchByFactor', () => {
         it('can scale by a factor of 2 about origin', () => {
             const square = TestHelper.square();
 
-            square.proportionalStretchTo(2);
+            square.proportionalStretchByFactor(2);
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(0, 0, 0, 1),
@@ -406,7 +406,7 @@ describe('WorkingGeometry', () => {
         it('can scale by a factor of 2 about (1, 1, 0)', () => {
             const square = TestHelper.square();
 
-            square.proportionalStretchTo(2, vec3.fromValues(1, 1, 0));
+            square.proportionalStretchByFactor(2, vec3.fromValues(1, 1, 0));
 
             expect(square.vertices).toEqualArrVec4([
                 vec4.fromValues(-1, -1, 0, 1),
@@ -418,7 +418,40 @@ describe('WorkingGeometry', () => {
         it('can scale by a factor of 1 and remain unchanged', () => {
             const square = TestHelper.square();
 
-            square.proportionalStretchTo(1);
+            square.proportionalStretchByFactor(1);
+
+            expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
+        });
+    });
+    describe('freeformStretchByFactor', () => {
+        it('can scale by a factor of 2 from (0, 1, 0) about origin', () => {
+            const square = TestHelper.square();
+
+            square.freeformStretchByFactor(2, vec3.fromValues(0, 1, 0));
+
+            expect(square.vertices).toEqualArrVec4([
+                vec4.fromValues(0, 0, 0, 1),
+                vec4.fromValues(0, 2, 0, 1),
+                vec4.fromValues(1, 2, 0, 1),
+                vec4.fromValues(1, 0, 0, 1)
+            ]);
+        });
+        it('can scale by a factor of 2 from (0, 0, 0) about (1, 1, 0)', () => {
+            const square = TestHelper.square();
+
+            square.freeformStretchByFactor(2, vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 0));
+
+            expect(square.vertices).toEqualArrVec4([
+                vec4.fromValues(-1, -1, 0, 1),
+                vec4.fromValues(-0.5, 0.5, 0, 1),
+                vec4.fromValues(1, 1, 0, 1),
+                vec4.fromValues(0.5, -0.5, 0, 1)
+            ]);
+        });
+        it('can scale by a factor of 1 and remain unchanged', () => {
+            const square = TestHelper.square();
+
+            square.proportionalStretchByFactor(1, vec3.fromValues(0, 1, 0));
 
             expect(square.vertices).toEqualArrVec4(TestHelper.square().vertices);
         });

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -30,7 +30,7 @@ export namespace TestHelper {
             vec3.fromValues(0, 0, -1),
             vec3.fromValues(0, 0, -1),
             vec3.fromValues(0, 0, -1),
-            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1)
         ];
         const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
         const controlPoints = [start];

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -26,6 +26,12 @@ export namespace TestHelper {
             vec3.fromValues(1, 1, 0),
             vec3.fromValues(1, 0, 0)
         ];
+        const normals = [
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+        ];
         const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
         const controlPoints = [start];
 
@@ -36,7 +42,7 @@ export namespace TestHelper {
             return out;
         });
 
-        return new WorkingGeometry(vertices, faces, controlPoints);
+        return new WorkingGeometry(vertices, normals, faces, controlPoints);
     }
 
     /**


### PR DESCRIPTION
With vertex normals, we get Phong shading for free, so we can now represent smooth surfaces in `WorkingGeometry`.

There were a few things I found that I think were incorrect before this PR:
- `WorkingGeometry` assumed that normals corresponded to faces in the WebGL buffers, but they actually correspond to vertices.
- `WorkingGeometry.scale` has been extended to work with non-collinear pull and destination points. The scale factors were also not being computed properly before.
- WorkingGeometry.scaleByFactor has been fixed to produce invertible matrices. There were cases before where the scale could be 0 (e.g., if pullPoint == destinationPoint).

Some of these changes have resulted in some functions being removed from WorkingGeometry.