### PR TITLE
Added `calder.ts` with top-level exports.

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -1,0 +1,78 @@
+/**
+ * Calder - A library for sculpting and manipulating complex 3D structures for
+ * the web.
+ *
+ * Copyright (c) 2018 Paul Bardea, Tammy Liu, Abhishek Madan, Andrew McBurney,
+ *                    and Dave Pagurek van Mossel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*****************************
+ * Armature
+ *****************************/
+
+export * from './armature/Armature';
+export * from './armature/Constraints';
+export * from './armature/Node';
+export * from './armature/Node';
+export * from './armature/NodeRenderObject';
+export * from './armature/Transformation';
+
+/*****************************
+ * Geometry
+ *****************************/
+
+export * from './geometry/BakedGeometry';
+export * from './geometry/MarchingCubes';
+export * from './geometry/ScalarField';
+export * from './geometry/Sphere';
+export * from './geometry/WorkingGeometry';
+
+/*****************************
+ * Math
+ *****************************/
+
+export * from './math/utils';
+
+/*****************************
+ * Renderer
+ *****************************/
+
+export * from './renderer/Camera';
+export * from './renderer/Renderer';
+export * from './renderer/interfaces/DebugParams';
+export * from './renderer/interfaces/RenderParams';
+export * from './renderer/interfaces/Light';
+export * from './renderer/interfaces/RenderObject';
+export * from './renderer/commands/createDrawAxes';
+export * from './renderer/commands/createDrawObject';
+
+/*****************************
+ * Types
+ *****************************/
+
+export * from './types/ConstraintTypes';
+export * from './types/VectorTypes';
+
+/*****************************
+ * Utils
+ *****************************/
+
+export * from './utils/affine';

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -31,16 +31,12 @@
 export * from './armature/Armature';
 export * from './armature/Constraints';
 export * from './armature/Node';
-export * from './armature/Node';
-export * from './armature/NodeRenderObject';
-export * from './armature/Transformation';
 
 /*****************************
  * Geometry
  *****************************/
 
 export * from './geometry/BakedGeometry';
-export * from './geometry/MarchingCubes';
 export * from './geometry/ScalarField';
 export * from './geometry/Sphere';
 export * from './geometry/WorkingGeometry';
@@ -70,9 +66,3 @@ export * from './renderer/commands/createDrawObject';
 
 export * from './types/ConstraintTypes';
 export * from './types/VectorTypes';
-
-/*****************************
- * Utils
- *****************************/
-
-export * from './utils/affine';


### PR DESCRIPTION
Like in the prototype, we had a top-level `calder.ts` file with exports for the library.