### PR TITLE
Store lazily created regl buffers

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -366,7 +366,7 @@ export class Node {
         const transformationMatrix = mat4.create();
         mat4.multiply(transformationMatrix, parentMatrix, transform);
 
-        return { ...Node.bone, transform: transformationMatrix, isShadeless: true };
+        return { geometry: Node.bone, transform: transformationMatrix, isShadeless: true };
     }
 
     /**
@@ -646,7 +646,7 @@ export class GeometryNode extends Node {
             isRoot,
             makeBones
         );
-        objects.geometry.push({ ...this.geometry, transform: currentMatrix });
+        objects.geometry.push({ geometry: this.geometry, transform: currentMatrix });
 
         return objects;
     }

--- a/src/geometry/BakedGeometry.ts
+++ b/src/geometry/BakedGeometry.ts
@@ -1,3 +1,6 @@
+// tslint:disable-next-line:import-name
+import REGL = require('regl');
+
 /**
  * After modelling is complete, a BakedGeometry should be returned for use in the renderer.
  */
@@ -6,4 +9,9 @@ export type BakedGeometry = {
     normals: Float32Array;
     indices: Int16Array;
     colors: Float32Array;
+
+    verticesBuffer?: REGL.Buffer;
+    normalsBuffer?: REGL.Buffer;
+    indicesBuffer?: REGL.Elements;
+    colorsBuffer?: REGL.Buffer;
 };

--- a/src/renderer/commands/createDrawObject.ts
+++ b/src/renderer/commands/createDrawObject.ts
@@ -31,10 +31,10 @@ export interface DrawObjectProps {
     model: mat4;
     cameraTransform: mat4;
     projectionMatrix: mat4;
-    positions: Float32Array;
-    normals: Float32Array;
-    colors: Float32Array;
-    indices: Int16Array;
+    positions: REGL.Buffer;
+    normals: REGL.Buffer;
+    colors: REGL.Buffer;
+    indices: REGL.Elements;
     numLights: number;
     ambientLight: vec3;
     isShadeless: boolean;

--- a/src/renderer/interfaces/RenderObject.ts
+++ b/src/renderer/interfaces/RenderObject.ts
@@ -5,7 +5,8 @@ import { BakedGeometry } from '../../geometry/BakedGeometry';
  * A collection of the properties needed to render something using the default
  * shader.
  */
-export type RenderObject = BakedGeometry & {
+export type RenderObject = {
+    geometry: BakedGeometry;
     transform: mat4;
 
     /**


### PR DESCRIPTION
So the last perf PR was good, but when rendering trees with a lot of nodes, it still ended up taking a lot of time to render. It no longer needed to construct a `Float32Array` every frame, but it still had to copy that data repeatedly onto the GPU. The majority of the time is now being spent on the `gl.bufferData` call, which is a WebGL primitive function: each object rendered needs to go back and copy data from the CPU.
![screen shot 2018-06-08 at 6 51 00 pm](https://user-images.githubusercontent.com/5315059/41184330-911e5b7a-6b4d-11e8-98bb-9168c41a759d.png)

What I opted for instead was to cache a `REGL.Buffer` for each primitive used, so that no information needs to be re-uploaded from the CPU to the GPU after the first time. Because we use the same primitive instances many times, this works really well right now:
![screen shot 2018-06-08 at 6 51 33 pm](https://user-images.githubusercontent.com/5315059/41184424-3d16412c-6b4e-11e8-8fcd-378cb7c2f4d5.png)

Unfortunately this will not work quite so well when we have many primitives or primitives with many vertices. In these cases, we'll probably want to cache as much as we can, but not run out of space on the GPU (maybe have some sort of cache so we can reuse as much as possible?) This is future work though, since we don't really have the capability yet of creating that sort of data.