### PR TITLE
Fix main script for npm exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">= 8.9.0"
   },
+  "main": "build/src/calder.js",
   "devDependencies": {
     "@types/gl-matrix": "^2.4.0",
     "@types/jest": "~22.2.2",


### PR DESCRIPTION
Looks like the thing that was preventing our module from loading was the lack of a specified entrypoint.