### PR TITLE
Initial implementation of color API.

### DIFF
--- a/src/calder.ts
+++ b/src/calder.ts
@@ -36,6 +36,7 @@ export * from './armature/Node';
  * Colors
  *****************************/
 
+export * from './colors/CMYKColor';
 export * from './colors/RGBColor';
 
 /*****************************

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -33,6 +33,12 @@ export * from './armature/Constraints';
 export * from './armature/Node';
 
 /*****************************
+ * Colors
+ *****************************/
+
+export * from './colors/RGBColor';
+
+/*****************************
  * Geometry
  *****************************/
 

--- a/src/colors/CMYKColor.ts
+++ b/src/colors/CMYKColor.ts
@@ -4,6 +4,12 @@ import { Color } from './Color';
 /**
  * An CMYK representation of a color in a WebGL context.
  *
+ * The acronym stands for:
+ *   C: `C`yan
+ *   M: `M`agenta
+ *   Y: `Y`ellow
+ *   K: blac`K`
+ *
  * @class CMYKColor
  */
 export class CMYKColor implements Color {

--- a/src/colors/CMYKColor.ts
+++ b/src/colors/CMYKColor.ts
@@ -109,7 +109,7 @@ export class CMYKColor implements Color {
 
         // Map the normalized RGB values for `this` to new RGB values
         const mappedColors = this.asArray().map(
-            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) / ratio
+            (c: number, i: number) => c * ratio + colorsArray[i] * (1 - ratio)
         );
 
         // Get the percentage of `K` (black)

--- a/src/colors/CMYKColor.ts
+++ b/src/colors/CMYKColor.ts
@@ -1,0 +1,97 @@
+import { vec3 } from 'gl-matrix';
+import { Color } from './Color';
+
+/**
+ * An CMYK representation of a color in a WebGL context.
+ *
+ * @class CMYKColor
+ */
+export class CMYKColor implements Color {
+    private cyan: number;
+    private magenta: number;
+    private yellow: number;
+    private black: number;
+
+    /**
+     * Instantiate a new CMYKColor object.
+     *
+     * @class CMYKColor
+     * @constructor
+     * @param {number} cyan Cyan percentage.
+     * @param {number} magenta Magenta percentage.
+     * @param {number} yellow Yellow percentage.
+     * @param {number} black Black percentage.
+     */
+    private constructor(cyan: number, magenta: number, yellow: number, black: number) {
+        if (cyan < 0 || cyan > 1) {
+            throw new RangeError(`cyan's value (${cyan}) must be in range [0, 1]`);
+        } else if (magenta < 0 || magenta > 1) {
+            throw new RangeError(`magenta's value (${magenta}) must be in range [0, 1]`);
+        } else if (yellow < 0 || yellow > 1) {
+            throw new RangeError(`yellow's value (${yellow}) must be in range [0, 1]`);
+        } else if (black < 0 || black > 1) {
+            throw new RangeError(`black's value (${black}) must be in range [0, 1]`);
+        }
+
+        this.cyan = cyan;
+        this.magenta = magenta;
+        this.yellow = yellow;
+        this.black = black;
+    }
+
+    /**
+     * Instantiates a new CMYKColor object from CMYK integer values.
+     *
+     * @class CMYKColor
+     * @method fromCMYK
+     * @param {number} cyan Cyan percentage.
+     * @param {number} magenta Magenta percentage.
+     * @param {number} yellow Yellow percentage.
+     * @param {number} black Black percentage.
+     * @returns {CMYKColor}
+     */
+    public static fromCMYK(
+        cyan: number,
+        magenta: number,
+        yellow: number,
+        black: number
+    ): CMYKColor {
+        return new CMYKColor(cyan, magenta, yellow, black);
+    }
+
+    /**
+     * Returns a three element array representation of the `CMYKColor` object.
+     *
+     * @class CMYKColor
+     * @method asArray
+     * @returns {number[]}
+     */
+    public asArray(): number[] {
+        return this.rgb();
+    }
+
+    /**
+     * Returns a gl-matrix `vec3` representation of the `CMYKColor` object.
+     *
+     * @class CMYKColor
+     * @method asVec
+     * @returns {gl-matrix.vec3}
+     */
+    public asVec(): vec3 {
+        const rgb = this.rgb();
+
+        return vec3.fromValues(rgb[0], rgb[1], rgb[2]);
+    }
+
+    public interpolate() {
+        // TODO(andrew)
+    }
+
+    private rgb(): number[] {
+        const red = (1 - this.cyan) * (1 - this.black);
+        const green = (1 - this.magenta) * (1 - this.black);
+        const blue = (1 - this.yellow) * (1 - this.black);
+
+        return [red, green, blue];
+    }
+}

--- a/src/colors/CMYKColor.ts
+++ b/src/colors/CMYKColor.ts
@@ -103,7 +103,7 @@ export class CMYKColor implements Color {
 
         // Map the normalized RGB values for `this` to new RGB values
         const mappedColors = this.asArray().map(
-            (c: number, i: number) => c * ratio + colorsArray[i] * (1 - ratio)
+            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) / ratio
         );
 
         // Get the percentage of `K` (black)

--- a/src/colors/Color.ts
+++ b/src/colors/Color.ts
@@ -7,7 +7,6 @@ export interface Color {
     /**
      * Returns a three element array representation of the `Color` object.
      *
-     * @class RGBColor
      * @method asArray
      * @returns {number[]}
      */
@@ -21,5 +20,13 @@ export interface Color {
      */
     asVec(): vec3;
 
-    interpolate();
+    /**
+     * Mix a color with another one.
+     *
+     * @method mix
+     * @param {Color} color The color object you wish to mix with `this`.
+     * @param {number} ratio The ratio at which to mix the first color with the second.
+     * @returns {Color}
+     */
+    mix(color: Color, seed: number);
 }

--- a/src/colors/Color.ts
+++ b/src/colors/Color.ts
@@ -1,0 +1,25 @@
+import { vec3 } from 'gl-matrix';
+
+/**
+ * A representation of a color in a WebGL context.
+ */
+export interface Color {
+    /**
+     * Returns a three element array representation of the `RGBColor` object.
+     *
+     * @class RGBColor
+     * @method asArray
+     * @returns {number[]}
+     */
+    asArray(): number[];
+
+    /**
+     * Returns a gl-matrix `vec3` representation of the `Color` object.
+     *
+     * @method asVec
+     * @returns {gl-matrix.vec3}
+     */
+    asVec(): vec3;
+
+    interpolate();
+}

--- a/src/colors/Color.ts
+++ b/src/colors/Color.ts
@@ -28,5 +28,5 @@ export interface Color {
      * @param {number} ratio The ratio at which to mix the first color with the second.
      * @returns {Color}
      */
-    mix(color: Color, seed: number);
+    mix(color: Color, ratio: number);
 }

--- a/src/colors/Color.ts
+++ b/src/colors/Color.ts
@@ -5,7 +5,7 @@ import { vec3 } from 'gl-matrix';
  */
 export interface Color {
     /**
-     * Returns a three element array representation of the `RGBColor` object.
+     * Returns a three element array representation of the `Color` object.
      *
      * @class RGBColor
      * @method asArray

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -44,8 +44,17 @@ export class RGBColor implements Color {
             throw new Error('Please pass in a hexadecimal string (i.e., FF33AA)');
         }
 
-        // Split hex string into segments of length 2
-        const hexValues = value.match(/.{2}/g)!.map((hex: string) => parseInt(hex, 16));
+        // Split the hexadecimal string into segments of length 2
+        const matches = value.match(/.{2}/g);
+
+        // Throw error if `matches` is null. Shouldn't be the case because of
+        // the previous assertion - but tslint was complaining ¯\_(ツ)_/¯
+        if (matches === null) {
+            throw new Error();
+        }
+
+        // Map the hexadecimal string segments to decimal integers
+        const hexValues = matches.map((hex: string) => parseInt(hex, 16));
 
         // Return the new color
         return new RGBColor(hexValues[0], hexValues[1], hexValues[2]);

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -16,6 +16,9 @@ export class RGBColor implements Color {
      *
      * @class RGBColor
      * @constructor
+     * @param {number} red Red numeric color value.
+     * @param {number} green Green numeric color value.
+     * @param {number} blue Blue numeric color value.
      */
     private constructor(red: number, green: number, blue: number) {
         if (red < 0 || red > 255) {

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -123,7 +123,7 @@ export class RGBColor implements Color {
 
         // Map the normalized RGB values for `this` to new RGB values
         const mappedColors = this.asArray().map(
-            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) * 255
+            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) * 255 / ratio
         );
 
         // Return a new RGB color mixed from the two

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -1,0 +1,97 @@
+import { vec3 } from 'gl-matrix';
+import { Color } from './Color';
+
+/**
+ * An RGB representation of a color in a WebGL context.
+ *
+ * @class RGBColor
+ */
+export class RGBColor implements Color {
+    private red: number;
+    private green: number;
+    private blue: number;
+
+    /**
+     * Instantiate a new RGBColor object.
+     *
+     * @class RGBColor
+     * @constructor
+     */
+    private constructor(red: number, green: number, blue: number) {
+        if (red < 0 || red > 255) {
+            throw new RangeError(`red's value (${red}) must be in range [0, 255]`);
+        } else if (green < 0 || green > 255) {
+            throw new RangeError(`green's value (${green}) must be in range [0, 255]`);
+        } else if (blue < 0 || blue > 255) {
+            throw new RangeError(`blue's value (${blue}) must be in range [0, 255]`);
+        }
+
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    /**
+     * Instantiates a new RGBColor object from a hex string.
+     *
+     * @class RGBColor
+     * @method fromHex
+     * @param {string} value A hex string of the form `FF0000`.
+     * @returns {RGBColor}
+     */
+    public static fromHex(value: string): RGBColor {
+        if (value.length !== 6) {
+            throw new Error("Please pass in a hexadecimal string (i.e., FF33AA)");
+        }
+
+        // Split hex string into segments of length 2
+        const hexValues = value.match(/.{2}/g)!.map((hex: string) => parseInt(hex, 16));
+
+        // Return the new color
+        return new RGBColor(hexValues[0], hexValues[1], hexValues[2]);
+    }
+
+    /**
+     * Instantiates a new RGBColor object from RGB integer values.
+     *
+     * @class RGBColor
+     * @method fromRGB
+     * @param {number} red Red numeric color value.
+     * @param {number} green Green numeric color value.
+     * @param {number} blue Blue numeric color value.
+     * @returns {RGBColor}
+     */
+    public static fromRGB(red: number, green: number, blue: number): RGBColor {
+        return new RGBColor(red, green, blue);
+    }
+
+    /**
+     * Returns a three element array representation of the `RGBColor` object.
+     *
+     * @class RGBColor
+     * @method asArray
+     * @returns {number[]}
+     */
+    public asArray(): number[] {
+        return [this.vecValue(this.red), this.vecValue(this.green), this.vecValue(this.blue)];
+    }
+
+    /**
+     * Returns a gl-matrix `vec3` representation of the `RGBColor` object.
+     *
+     * @class RGBColor
+     * @method asVec
+     * @returns {gl-matrix.vec3}
+     */
+    public asVec(): vec3 {
+        return vec3.fromValues(this.vecValue(this.red), this.vecValue(this.green), this.vecValue(this.blue));
+    }
+
+    public interpolate() {
+        // TODO(andrew)
+    }
+
+    private vecValue(value: number): number {
+        return value / 255.0;
+    }
+}

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -44,16 +44,21 @@ export class RGBColor implements Color {
      *
      * @class RGBColor
      * @method fromHex
-     * @param {string} value A hex string of the form `FF0000`.
+     * @param {string} value A hex string of the form `FF0000` or `#FF0000`.
      * @returns {RGBColor}
      */
     public static fromHex(value: string): RGBColor {
-        if (value.length !== 6) {
-            throw new Error('Please pass in a hexadecimal string (i.e., FF33AA)');
+        // Ensure the user passed in a valid hexadecimal string
+        if (
+            value.length > 7 ||
+            value.length < 6 ||
+            (value.length === 7 && value.lastIndexOf('#', 0) !== 0)
+        ) {
+            throw new Error('Please pass in a valid hexadecimal string (i.e., FF33AA or #FF33AA)');
         }
 
         // Split the hexadecimal string into segments of length 2
-        const matches = value.match(/.{2}/g);
+        const matches = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
 
         // Throw error if `matches` is null. Shouldn't be the case because of
         // the previous assertion - but tslint was complaining ¯\_(ツ)_/¯
@@ -62,7 +67,7 @@ export class RGBColor implements Color {
         }
 
         // Map the hexadecimal string segments to decimal integers
-        const hexValues = matches.map((hex: string) => parseInt(hex, 16));
+        const hexValues = matches.slice(1).map((hex: string) => parseInt(hex, 16));
 
         // Return the new color
         return new RGBColor(hexValues[0], hexValues[1], hexValues[2]);

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -128,7 +128,7 @@ export class RGBColor implements Color {
 
         // Map the normalized RGB values for `this` to new RGB values
         const mappedColors = this.asArray().map(
-            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) * 255 / ratio
+            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) * 255
         );
 
         // Return a new RGB color mixed from the two

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -103,8 +103,31 @@ export class RGBColor implements Color {
         );
     }
 
-    public interpolate() {
-        // TODO(andrew)
+    /**
+     * Mix a color with another one. By default, it will mix the two colors
+     * equally with a `ratio` value of `0.5`.
+     *
+     * @method mix
+     * @param {Color} color The color object you wish to mix with `this`.
+     * @param {number} ratio The ratio at which to mix the first color with the second.
+     * @returns {RGBColor}
+     */
+    public mix(color: Color, ratio: number = 0.5) {
+        // Assert the ratio is within the range [0, 1]
+        if (ratio < 0 || ratio > 1) {
+            throw new RangeError(`ratio's value (${ratio}) must be in range [0, 1]`);
+        }
+
+        // Get the normalized RGB values for the second color
+        const colorsArray = color.asArray();
+
+        // Map the normalized RGB values for `this` to new RGB values
+        const mappedColors = this.asArray().map(
+            (c: number, i: number) => (c * ratio + colorsArray[i] * (1 - ratio)) * 255
+        );
+
+        // Return a new RGB color mixed from the two
+        return new RGBColor(mappedColors[0], mappedColors[1], mappedColors[2]);
     }
 
     private vecValue(value: number): number {

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -41,7 +41,7 @@ export class RGBColor implements Color {
      */
     public static fromHex(value: string): RGBColor {
         if (value.length !== 6) {
-            throw new Error("Please pass in a hexadecimal string (i.e., FF33AA)");
+            throw new Error('Please pass in a hexadecimal string (i.e., FF33AA)');
         }
 
         // Split hex string into segments of length 2
@@ -84,7 +84,11 @@ export class RGBColor implements Color {
      * @returns {gl-matrix.vec3}
      */
     public asVec(): vec3 {
-        return vec3.fromValues(this.vecValue(this.red), this.vecValue(this.green), this.vecValue(this.blue));
+        return vec3.fromValues(
+            this.vecValue(this.red),
+            this.vecValue(this.green),
+            this.vecValue(this.blue)
+        );
     }
 
     public interpolate() {

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -4,6 +4,11 @@ import { Color } from './Color';
 /**
  * An RGB representation of a color in a WebGL context.
  *
+ * The acronym stands for:
+ *   R: `R`ed
+ *   G: `G`reen
+ *   B: `B`lue
+ *
  * @class RGBColor
  */
 export class RGBColor implements Color {

--- a/src/colors/RGBColor.ts
+++ b/src/colors/RGBColor.ts
@@ -48,22 +48,12 @@ export class RGBColor implements Color {
      * @returns {RGBColor}
      */
     public static fromHex(value: string): RGBColor {
-        // Ensure the user passed in a valid hexadecimal string
-        if (
-            value.length > 7 ||
-            value.length < 6 ||
-            (value.length === 7 && value.lastIndexOf('#', 0) !== 0)
-        ) {
-            throw new Error('Please pass in a valid hexadecimal string (i.e., FF33AA or #FF33AA)');
-        }
-
         // Split the hexadecimal string into segments of length 2
         const matches = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
 
-        // Throw error if `matches` is null. Shouldn't be the case because of
-        // the previous assertion - but tslint was complaining ¯\_(ツ)_/¯
+        // Ensure the user passed in a valid hexadecimal string
         if (matches === null) {
-            throw new Error();
+            throw new Error('Please pass in a valid hexadecimal string (i.e., FF33AA or #FF33AA)');
         }
 
         // Map the hexadecimal string segments to decimal integers

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -8,7 +8,7 @@ import { Renderer } from '../renderer/Renderer';
 import { mat4, quat, vec3 } from 'gl-matrix';
 import { flatMap, range } from 'lodash';
 import { Constraints } from '../armature/Constraints';
-import { RGBColor } from '../calder';
+import { CMYKColor } from '../calder';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
 const light2: Light = { lightPosition: [700, 500, 50], lightColor: [3, 3, 3], lightIntensity: 100 };
@@ -24,7 +24,7 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-const red: number[] = RGBColor.fromHex('FF0000').asArray();
+const red: number[] = CMYKColor.fromCMYK(0, 1, 1, 0).asArray();
 sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => red));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -8,7 +8,7 @@ import { Renderer } from '../renderer/Renderer';
 import { mat4, quat, vec3 } from 'gl-matrix';
 import { flatMap, range } from 'lodash';
 import { Constraints } from '../armature/Constraints';
-import { CMYKColor } from '../calder';
+import { CMYKColor, RGBColor } from '../calder';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
 const light2: Light = { lightPosition: [700, 500, 50], lightColor: [3, 3, 3], lightIntensity: 100 };
@@ -24,8 +24,12 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-const red: number[] = CMYKColor.fromCMYK(0, 1, 1, 0).asArray();
-sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => red));
+
+// Populate sphere colours
+const blue: RGBColor = RGBColor.fromHex('0000FF');
+const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+const purple: CMYKColor = red.mix(blue);
+sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => purple.asArray()));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -8,6 +8,7 @@ import { Renderer } from '../renderer/Renderer';
 import { mat4, quat, vec3 } from 'gl-matrix';
 import { flatMap, range } from 'lodash';
 import { Constraints } from '../armature/Constraints';
+import { RGBColor } from '../calder';
 
 const light1: Light = { lightPosition: [10, 10, 10], lightColor: [1, 1, 1], lightIntensity: 256 };
 const light2: Light = { lightPosition: [700, 500, 50], lightColor: [3, 3, 3], lightIntensity: 100 };
@@ -23,7 +24,8 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => [1, 0, 0]));
+const red: number[] = RGBColor.fromHex("FF0000").asArray();
+sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => red));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -24,7 +24,7 @@ renderer.addLight(light1);
 renderer.addLight(light2);
 
 const sphere = genSphere();
-const red: number[] = RGBColor.fromHex("FF0000").asArray();
+const red: number[] = RGBColor.fromHex('FF0000').asArray();
 sphere.colors = Int16Array.from(flatMap(range(sphere.vertices.length / 3), () => red));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/colors/CMYKColor.spec.ts
+++ b/tests/colors/CMYKColor.spec.ts
@@ -1,5 +1,5 @@
 import { vec3 } from 'gl-matrix';
-import { CMYKColor } from "../../src/calder";
+import { CMYKColor } from '../../src/calder';
 
 import '../glMatrix';
 
@@ -80,7 +80,7 @@ describe('CMYKColor', () => {
             const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
             const purple: CMYKColor = red.mix(blue);
 
-            expect(purple.asArray()).toEqual([1, 0, 1]);
+            expect(purple.asArray()).toEqual([0.5, 0, 0.5]);
         });
 
         it('properly mixes colors with a ratio provided', () => {

--- a/tests/colors/CMYKColor.spec.ts
+++ b/tests/colors/CMYKColor.spec.ts
@@ -1,0 +1,94 @@
+import { vec3 } from 'gl-matrix';
+import { CMYKColor } from "../../src/calder";
+
+import '../glMatrix';
+
+describe('CMYKColor', () => {
+    describe('CMYKColor.fromCMYK', () => {
+        it('properly returns the appropriate normalized CMYK values', () => {
+            const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+            const green: CMYKColor = CMYKColor.fromCMYK(1, 0, 1, 0);
+            const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
+
+            expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(green.asArray()).toEqual([0, 1, 0]);
+            expect(blue.asArray()).toEqual([0, 0, 1]);
+        });
+
+        it('properly throws errors for invalid CMYK value ranges', () => {
+            expect(() => {
+                CMYKColor.fromCMYK(-1, 0, 0, 0);
+            }).toThrow("cyan's value (-1) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(2, 0, 0, 0);
+            }).toThrow("cyan's value (2) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, -1, 0, 0);
+            }).toThrow("magenta's value (-1) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, 2, 0, 0);
+            }).toThrow("magenta's value (2) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, 0, -1, 0);
+            }).toThrow("yellow's value (-1) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, 0, 2, 0);
+            }).toThrow("yellow's value (2) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, 0, 0, -1);
+            }).toThrow("black's value (-1) must be in range [0, 1]");
+
+            expect(() => {
+                CMYKColor.fromCMYK(0, 0, 0, 2);
+            }).toThrow("black's value (2) must be in range [0, 1]");
+        });
+    });
+
+    describe('asArray', () => {
+        it('properly returns the appropriate normalized CMYK values in an array representation', () => {
+            const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+            const green: CMYKColor = CMYKColor.fromCMYK(1, 0, 1, 0);
+            const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
+
+            expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(green.asArray()).toEqual([0, 1, 0]);
+            expect(blue.asArray()).toEqual([0, 0, 1]);
+        });
+    });
+
+    describe('asVec', () => {
+        it('properly returns the appropriate normalized CMYK values in an array representation', () => {
+            const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+            const green: CMYKColor = CMYKColor.fromCMYK(1, 0, 1, 0);
+            const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
+
+            expect(red.asVec()).toEqualVec3(vec3.fromValues(1, 0, 0));
+            expect(green.asVec()).toEqualVec3(vec3.fromValues(0, 1, 0));
+            expect(blue.asVec()).toEqualVec3(vec3.fromValues(0, 0, 1));
+        });
+    });
+
+    describe('mix', () => {
+        it('properly mixes colors with no ratio provided', () => {
+            const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+            const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
+            const purple: CMYKColor = red.mix(blue);
+
+            expect(purple.asArray()).toEqual([1, 0, 1]);
+        });
+
+        it('properly mixes colors with a ratio provided', () => {
+            const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
+            const blue: CMYKColor = CMYKColor.fromCMYK(1, 1, 0, 0);
+            const purple: CMYKColor = red.mix(blue, 0.25);
+
+            expect(purple.asArray()).toEqual([0.25, 0, 0.75]);
+        });
+    });
+});

--- a/tests/colors/RGBColor.spec.ts
+++ b/tests/colors/RGBColor.spec.ts
@@ -1,14 +1,14 @@
 import { vec3 } from 'gl-matrix';
-import { RGBColor } from "../../src/calder";
+import { RGBColor } from '../../src/calder';
 
 import '../glMatrix';
 
 describe('RGBColor', () => {
     describe('RGBColor.fromHex', () => {
         it('properly returns the appropriate normalized RGB values', () => {
-            const red: RGBColor = RGBColor.fromHex("FF0000");
-            const green: RGBColor = RGBColor.fromHex("00FF00");
-            const blue: RGBColor = RGBColor.fromHex("0000FF");
+            const red: RGBColor = RGBColor.fromHex('FF0000');
+            const green: RGBColor = RGBColor.fromHex('00FF00');
+            const blue: RGBColor = RGBColor.fromHex('0000FF');
 
             expect(red.asArray()).toEqual([1, 0, 0]);
             expect(green.asArray()).toEqual([0, 1, 0]);
@@ -17,15 +17,15 @@ describe('RGBColor', () => {
 
         it('properly throws errors for invalid hexadecimal strings', () => {
             expect(() => {
-                RGBColor.fromHex("#FF0000");
+                RGBColor.fromHex('#FF0000');
             }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
 
             expect(() => {
-                RGBColor.fromHex("FF");
+                RGBColor.fromHex('FF');
             }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
 
             expect(() => {
-                RGBColor.fromHex("FFFFFFF");
+                RGBColor.fromHex('FFFFFFF');
             }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
         });
     });
@@ -70,9 +70,9 @@ describe('RGBColor', () => {
 
     describe('asArray', () => {
         it('properly returns the appropriate normalized RGB values in an array representation', () => {
-            const red: RGBColor = RGBColor.fromHex("FF0000");
-            const green: RGBColor = RGBColor.fromHex("00FF00");
-            const blue: RGBColor = RGBColor.fromHex("0000FF");
+            const red: RGBColor = RGBColor.fromHex('FF0000');
+            const green: RGBColor = RGBColor.fromHex('00FF00');
+            const blue: RGBColor = RGBColor.fromHex('0000FF');
 
             expect(red.asArray()).toEqual([1, 0, 0]);
             expect(green.asArray()).toEqual([0, 1, 0]);
@@ -82,9 +82,9 @@ describe('RGBColor', () => {
 
     describe('asVec', () => {
         it('properly returns the appropriate normalized RGB values in an array representation', () => {
-            const red: RGBColor = RGBColor.fromHex("FF0000");
-            const green: RGBColor = RGBColor.fromHex("00FF00");
-            const blue: RGBColor = RGBColor.fromHex("0000FF");
+            const red: RGBColor = RGBColor.fromHex('FF0000');
+            const green: RGBColor = RGBColor.fromHex('00FF00');
+            const blue: RGBColor = RGBColor.fromHex('0000FF');
 
             expect(red.asVec()).toEqualVec3(vec3.fromValues(1, 0, 0));
             expect(green.asVec()).toEqualVec3(vec3.fromValues(0, 1, 0));
@@ -98,7 +98,7 @@ describe('RGBColor', () => {
             const blue: RGBColor = RGBColor.fromHex('0000FF');
             const purple: RGBColor = red.mix(blue);
 
-            expect(purple.asArray()).toEqual([1, 0, 1]);
+            expect(purple.asArray()).toEqual([0.5, 0, 0.5]);
         });
 
         it('properly mixes colors with a ratio provided', () => {

--- a/tests/colors/RGBColor.spec.ts
+++ b/tests/colors/RGBColor.spec.ts
@@ -7,26 +7,24 @@ describe('RGBColor', () => {
     describe('RGBColor.fromHex', () => {
         it('properly returns the appropriate normalized RGB values', () => {
             const red: RGBColor = RGBColor.fromHex('FF0000');
+            const redTwo: RGBColor = RGBColor.fromHex('#FF0000');
             const green: RGBColor = RGBColor.fromHex('00FF00');
             const blue: RGBColor = RGBColor.fromHex('0000FF');
 
             expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(redTwo.asArray()).toEqual([1, 0, 0]);
             expect(green.asArray()).toEqual([0, 1, 0]);
             expect(blue.asArray()).toEqual([0, 0, 1]);
         });
 
         it('properly throws errors for invalid hexadecimal strings', () => {
             expect(() => {
-                RGBColor.fromHex('#FF0000');
-            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
-
-            expect(() => {
                 RGBColor.fromHex('FF');
-            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
+            }).toThrow('Please pass in a valid hexadecimal string (i.e., FF33AA or #FF33AA)');
 
             expect(() => {
                 RGBColor.fromHex('FFFFFFF');
-            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
+            }).toThrow('Please pass in a valid hexadecimal string (i.e., FF33AA or #FF33AA)');
         });
     });
 

--- a/tests/colors/RGBColor.spec.ts
+++ b/tests/colors/RGBColor.spec.ts
@@ -1,0 +1,112 @@
+import { vec3 } from 'gl-matrix';
+import { RGBColor } from "../../src/calder";
+
+import '../glMatrix';
+
+describe('RGBColor', () => {
+    describe('RGBColor.fromHex', () => {
+        it('properly returns the appropriate normalized RGB values', () => {
+            const red: RGBColor = RGBColor.fromHex("FF0000");
+            const green: RGBColor = RGBColor.fromHex("00FF00");
+            const blue: RGBColor = RGBColor.fromHex("0000FF");
+
+            expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(green.asArray()).toEqual([0, 1, 0]);
+            expect(blue.asArray()).toEqual([0, 0, 1]);
+        });
+
+        it('properly throws errors for invalid hexadecimal strings', () => {
+            expect(() => {
+                RGBColor.fromHex("#FF0000");
+            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
+
+            expect(() => {
+                RGBColor.fromHex("FF");
+            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
+
+            expect(() => {
+                RGBColor.fromHex("FFFFFFF");
+            }).toThrow('Please pass in a hexadecimal string (i.e., FF33AA)');
+        });
+    });
+
+    describe('RGBColor.fromRGB', () => {
+        it('properly returns the appropriate normalized RGB values', () => {
+            const red: RGBColor = RGBColor.fromRGB(255, 0, 0);
+            const green: RGBColor = RGBColor.fromRGB(0, 255, 0);
+            const blue: RGBColor = RGBColor.fromRGB(0, 0, 255);
+
+            expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(green.asArray()).toEqual([0, 1, 0]);
+            expect(blue.asArray()).toEqual([0, 0, 1]);
+        });
+
+        it('properly throws errors for invalid RGB value ranges', () => {
+            expect(() => {
+                RGBColor.fromRGB(-1, 0, 0);
+            }).toThrow("red's value (-1) must be in range [0, 255]");
+
+            expect(() => {
+                RGBColor.fromRGB(256, 0, 0);
+            }).toThrow("red's value (256) must be in range [0, 255]");
+
+            expect(() => {
+                RGBColor.fromRGB(0, -1, 0);
+            }).toThrow("green's value (-1) must be in range [0, 255]");
+
+            expect(() => {
+                RGBColor.fromRGB(0, 256, 0);
+            }).toThrow("green's value (256) must be in range [0, 255]");
+
+            expect(() => {
+                RGBColor.fromRGB(0, 0, -1);
+            }).toThrow("blue's value (-1) must be in range [0, 255]");
+
+            expect(() => {
+                RGBColor.fromRGB(0, 0, 256);
+            }).toThrow("blue's value (256) must be in range [0, 255]");
+        });
+    });
+
+    describe('asArray', () => {
+        it('properly returns the appropriate normalized RGB values in an array representation', () => {
+            const red: RGBColor = RGBColor.fromHex("FF0000");
+            const green: RGBColor = RGBColor.fromHex("00FF00");
+            const blue: RGBColor = RGBColor.fromHex("0000FF");
+
+            expect(red.asArray()).toEqual([1, 0, 0]);
+            expect(green.asArray()).toEqual([0, 1, 0]);
+            expect(blue.asArray()).toEqual([0, 0, 1]);
+        });
+    });
+
+    describe('asVec', () => {
+        it('properly returns the appropriate normalized RGB values in an array representation', () => {
+            const red: RGBColor = RGBColor.fromHex("FF0000");
+            const green: RGBColor = RGBColor.fromHex("00FF00");
+            const blue: RGBColor = RGBColor.fromHex("0000FF");
+
+            expect(red.asVec()).toEqualVec3(vec3.fromValues(1, 0, 0));
+            expect(green.asVec()).toEqualVec3(vec3.fromValues(0, 1, 0));
+            expect(blue.asVec()).toEqualVec3(vec3.fromValues(0, 0, 1));
+        });
+    });
+
+    describe('mix', () => {
+        it('properly mixes colors with no ratio provided', () => {
+            const red: RGBColor = RGBColor.fromRGB(255, 0, 0);
+            const blue: RGBColor = RGBColor.fromHex('0000FF');
+            const purple: RGBColor = red.mix(blue);
+
+            expect(purple.asArray()).toEqual([1, 0, 1]);
+        });
+
+        it('properly mixes colors with a ratio provided', () => {
+            const red: RGBColor = RGBColor.fromRGB(255, 0, 0);
+            const blue: RGBColor = RGBColor.fromHex('0000FF');
+            const purple: RGBColor = red.mix(blue, 0.25);
+
+            expect(purple.asArray()).toEqual([0.25, 0, 0.75]);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #53.

### Todo

- [x] `mix` method for RGB and CMYK classes.
- [x] Fix unit tests for new color code (by fixing the `mix` methods in RGB and CMYK classes).
- [x] Add CMYK class implementing the `Color` interface.