### PR TITLE
Add normals to Cube helper object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
         
       - run: yarn build
-      - run: yarn webpack
       - run: yarn lint
       - run: yarn check-format
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
         
       - run: yarn build
+      - run: yarn webpack
       - run: yarn lint
       - run: yarn check-format
       - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ npm-debug.log*
 
 # Transpiled files
 build/
+src/**/*.js
+src/**/*.js.map
+tests/**/*.js
+tests/**/*.js.map

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "clean": "rimraf coverage build tmp",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.json",
     "check-tslint": "tslint-config-prettier-check ./tslint.json",
     "check-format": "prettier --list-different '**/*.ts'",
     "fix-format": "prettier --write '**/*.ts'",

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -30,13 +30,15 @@ export class WorkingGeometry {
     /**
      * The points that make up the geometry, in no particular order. For each vertex v, v[3] must
      * be equal to 0 to ensure that it is a point in Affine space rather than a vector.
+     *
+     * For faceted objects, a vertex is needed for every facet it touches.
+     *
      */
     public vertices: vec4[];
 
     /**
-     * The normals that correspond to the vertices. For each vertex, it must retain a copy of
-     * the normal for each face it composes. For each normal n, n[3] must be equal to 1 to ensure
-     * that it is a vector.
+     * The normals that correspond to the vertices. For each normal n, n[3] must be equal to 1 to
+     * ensure that it is a vector.
      */
     public normals: vec4[];
 

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -34,8 +34,9 @@ export class WorkingGeometry {
     public vertices: vec4[];
 
     /**
-     * The normals that correspond to the vertices. For each normal n, n[3] must be equal to 1 to
-     * ensure that it is a vector.
+     * The normals that correspond to the vertices. For each vertex, it must retain a copy of
+     * the normal for each face it composes. For each normal n, n[3] must be equal to 1 to ensure
+     * that it is a vector.
      */
     public normals: vec4[];
 

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -81,13 +81,37 @@ export namespace TestHelper {
             vec3.fromValues(1, 0, 1)
         ];
         const normals = [
+            // Vertex 0
+            vec3.fromValues(-1, 0, 0),
+            vec3.fromValues(0, -1, 0),
             vec3.fromValues(0, 0, -1),
+            // Vertex 1
+            vec3.fromValues(-1, 0, 0),
+            vec3.fromValues(0, 1, 0),
             vec3.fromValues(0, 0, -1),
+            // Vertex 2
+            vec3.fromValues(1, 0, 0),
+            vec3.fromValues(0, 1, 0),
             vec3.fromValues(0, 0, -1),
+            // Vertex 3
+            vec3.fromValues(1, 0, 0),
+            vec3.fromValues(0, -1, 0),
             vec3.fromValues(0, 0, -1),
+            // Vertex 4
+            vec3.fromValues(-1, 0, 0),
+            vec3.fromValues(0, -1, 0),
             vec3.fromValues(0, 0, 1),
+            // Vertex 5
+            vec3.fromValues(-1, 0, 0),
+            vec3.fromValues(0, 1, 0),
             vec3.fromValues(0, 0, 1),
+            // Vertex 6
+            vec3.fromValues(1, 0, 0),
+            vec3.fromValues(0, 1, 0),
             vec3.fromValues(0, 0, 1),
+            // Vertex 7
+            vec3.fromValues(1, 0, 0),
+            vec3.fromValues(0, -1, 0),
             vec3.fromValues(0, 0, 1)
         ];
         const faces = [

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -1,6 +1,8 @@
 import { vec3 } from 'gl-matrix';
 import { Face, WorkingGeometry } from '../../src/geometry/WorkingGeometry';
 
+import { flatMap } from 'lodash';
+
 export namespace TestHelper {
     /**
      * Creates a square whose front-lower-left corner is at `start` and that has a width of `size`.
@@ -68,7 +70,7 @@ export namespace TestHelper {
 		 *    |/      |/    |/
 		 *    0-------3     +--x
 		 */
-        const unitVertices = [
+        const cubeVertices = [
             // Front side of cube.
             vec3.fromValues(0, 0, 0),
             vec3.fromValues(0, 1, 0),
@@ -80,63 +82,62 @@ export namespace TestHelper {
             vec3.fromValues(1, 1, 1),
             vec3.fromValues(1, 0, 1)
         ];
-        const normals = [
-            // Vertex 0
-            vec3.fromValues(-1, 0, 0),
-            vec3.fromValues(0, -1, 0),
-            vec3.fromValues(0, 0, -1),
-            // Vertex 1
-            vec3.fromValues(-1, 0, 0),
-            vec3.fromValues(0, 1, 0),
-            vec3.fromValues(0, 0, -1),
-            // Vertex 2
-            vec3.fromValues(1, 0, 0),
-            vec3.fromValues(0, 1, 0),
-            vec3.fromValues(0, 0, -1),
-            // Vertex 3
-            vec3.fromValues(1, 0, 0),
-            vec3.fromValues(0, -1, 0),
-            vec3.fromValues(0, 0, -1),
-            // Vertex 4
-            vec3.fromValues(-1, 0, 0),
-            vec3.fromValues(0, -1, 0),
-            vec3.fromValues(0, 0, 1),
-            // Vertex 5
-            vec3.fromValues(-1, 0, 0),
-            vec3.fromValues(0, 1, 0),
-            vec3.fromValues(0, 0, 1),
-            // Vertex 6
-            vec3.fromValues(1, 0, 0),
-            vec3.fromValues(0, 1, 0),
-            vec3.fromValues(0, 0, 1),
-            // Vertex 7
-            vec3.fromValues(1, 0, 0),
-            vec3.fromValues(0, -1, 0),
-            vec3.fromValues(0, 0, 1)
+        const unitPositions = [
+            // Front
+            cubeVertices[0],
+            cubeVertices[1],
+            cubeVertices[2],
+            cubeVertices[3],
+            // Left
+            cubeVertices[0],
+            cubeVertices[1],
+            cubeVertices[5],
+            cubeVertices[4],
+            // Back
+            cubeVertices[4],
+            cubeVertices[5],
+            cubeVertices[6],
+            cubeVertices[7],
+            // Right
+            cubeVertices[3],
+            cubeVertices[2],
+            cubeVertices[6],
+            cubeVertices[7],
+            // Top
+            cubeVertices[1],
+            cubeVertices[5],
+            cubeVertices[6],
+            cubeVertices[2],
+            // Bottom
+            cubeVertices[0],
+            cubeVertices[4],
+            cubeVertices[7],
+            cubeVertices[3]
         ];
-        const faces = [
-            // Front side
-            new Face([0, 1, 2]),
-            new Face([0, 2, 3]),
-            // Left side
-            new Face([0, 1, 5]),
-            new Face([1, 4, 5]),
-            // Right side
-            new Face([3, 2, 6]),
-            new Face([3, 6, 7]),
-            // Back side
-            new Face([4, 5, 6]),
-            new Face([4, 6, 7]),
-            // Top side
-            new Face([1, 2, 6]),
-            new Face([1, 5, 6]),
-            // Bottom side
-            new Face([0, 4, 7]),
-            new Face([0, 3, 7])
+        const normalDirections = [
+            // Front
+            vec3.fromValues(0, 0, -1),
+            // Left
+            vec3.fromValues(-1, 0, 0),
+            // Back
+            vec3.fromValues(0, 0, 1),
+            // Right
+            vec3.fromValues(1, 0, 0),
+            // Top
+            vec3.fromValues(0, 1, 0),
+            // Bottom
+            vec3.fromValues(0, -1, 0)
         ];
+        const normals = flatMap(normalDirections, (v: vec3) => [v, v, v, v]);
+        const faces: Face[] = [];
+        for (let i = 0; i < 6; i += 1) {
+            const base = i * 4;
+            faces.push(new Face([base, base + 1, base + 2]));
+            faces.push(new Face([base, base + 2, base + 3]));
+        }
         const controlPoints = [start];
 
-        const vertices = unitVertices.map((vertex: vec3) => {
+        const vertices = unitPositions.map((vertex: vec3) => {
             const out = vec3.create();
             vec3.scaleAndAdd(out, start, vertex, size);
 

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -80,6 +80,16 @@ export namespace TestHelper {
             vec3.fromValues(1, 1, 1),
             vec3.fromValues(1, 0, 1)
         ];
+        const normals = [
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, -1),
+            vec3.fromValues(0, 0, 1),
+            vec3.fromValues(0, 0, 1),
+            vec3.fromValues(0, 0, 1),
+            vec3.fromValues(0, 0, 1)
+        ];
         const faces = [
             // Front side
             new Face([0, 1, 2]),
@@ -109,6 +119,6 @@ export namespace TestHelper {
             return out;
         });
 
-        return new WorkingGeometry(vertices, faces, controlPoints);
+        return new WorkingGeometry(vertices, normals, faces, controlPoints);
     }
 }


### PR DESCRIPTION
`yarn webpack` does not run since there is an error in `helper.ts` where the Cube object was not passed in a set of normals.