### PR TITLE
Save random generator in constructor

### DIFF
--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -1,3 +1,4 @@
+import { RandomGenerator } from '../utils/random';
 import { Node, Point } from './Node';
 
 import { range } from 'lodash';
@@ -20,6 +21,7 @@ export class Generator {
     private rules: { [name: string]: { totalWeight: number; definitions: Definition[] } } = {};
     private spawnPoints: SpawnPoint[] = [];
     private nextSpawnPoints: SpawnPoint[] = [];
+    private random: RandomGenerator = Math.random;
 
     /**
      * Define a component to procedurally generate a component of a struture.
@@ -107,7 +109,7 @@ export class Generator {
             throw new Error(`Cannot find definition for component "${component}"`);
         }
 
-        const value = Math.random() * this.rules[component].totalWeight;
+        const value = this.random() * this.rules[component].totalWeight;
         let weight = 0;
         for (const definition of this.rules[component].definitions) {
             weight += definition.weight;

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,4 @@
+/**
+ * Generates a random number between 0 and 1.
+ */
+export type RandomGenerator = () => number;


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/71

Basically, we already implemented separate random seeds in the editor, but it only works right now because our example code happens to not use any runtime random number generation. We need to have any internal functions that use random numbers capture the generator when constructed, and then use that at runtime.

In the future when implementing https://github.com/calder-gl/calder/issues/52, it will also need to use the pattern of saving a reference to the current random number generator in the constructor.