### PR TITLE
Add rotate- and scale-by-amount methods

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -4,7 +4,6 @@ import { closestPointOnLine, coord, coordFunc, BakedGeometry, RenderObject } fro
 import { vec3From4, vec3ToPoint } from '../math/utils';
 import { matrix4, vector3 } from '../types/InternalVectorTypes';
 import { Mapper } from '../utils/mapper';
-import { RandomGenerator } from '../utils/random';
 import { NodeRenderObject } from './NodeRenderObject';
 import { Transformation } from './Transformation';
 
@@ -52,7 +51,6 @@ export class Node {
     private anchor: vec3 | null = null;
     private held: vec3[] = [];
     private grabbed: vec3 | null = null;
-    private random: RandomGenerator = Math.random;
 
     /**
      * Instantiates a new `Node`.

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -1,9 +1,10 @@
-import { mat3, mat4, quat, vec3, vec4 } from 'gl-matrix';
-import { flatten, flatMap } from 'lodash';
+import { glMatrix, mat3, mat4, quat, vec3, vec4 } from 'gl-matrix';
+import { flatten, flatMap, isNumber } from 'lodash';
 import { closestPointOnLine, coord, coordFunc, BakedGeometry, RenderObject } from '../calder';
 import { vec3From4, vec3ToPoint } from '../math/utils';
 import { matrix4, vector3 } from '../types/InternalVectorTypes';
 import { Mapper } from '../utils/mapper';
+import { RandomGenerator } from '../utils/random';
 import { NodeRenderObject } from './NodeRenderObject';
 import { Transformation } from './Transformation';
 
@@ -51,6 +52,7 @@ export class Node {
     private anchor: vec3 | null = null;
     private held: vec3[] = [];
     private grabbed: vec3 | null = null;
+    private random: RandomGenerator = Math.random;
 
     /**
      * Instantiates a new `Node`.
@@ -133,6 +135,100 @@ export class Node {
      */
     public grab(point: Point | coord): Node {
         this.grabbed = this.localPointCoordinate(point);
+
+        return this;
+    }
+
+    /**
+     * Scales the node by the specified amount, either about the node's origin or a single
+     * constrained point.
+     *
+     * @param {number | coord} amount The amount to scale by, either the same in each axis or the
+     * components for each axis.
+     * @returns {Node} The current node, for method chaining.
+     */
+    public scale(amount: number | coord): Node {
+        const amountVec = isNumber(amount)
+            ? vec3.fromValues(amount, amount, amount)
+            : Mapper.coordToVector(amount);
+        const constrainedPoints: vec3[] = [...this.held];
+
+        // If the node is attached to a parent node with an anchor, add it to the list of
+        // constrained points.
+        if (this.anchor !== null) {
+            constrainedPoints.push(this.anchor);
+        }
+
+        if (constrainedPoints.length > 1) {
+            throw new Error("Can't scale when more than one point is held!");
+        }
+
+        const anchor =
+            constrainedPoints.length > 0 ? constrainedPoints[0] : vec3.fromValues(0, 0, 0);
+
+        const incScaling = mat4.fromTranslation(mat4.create(), anchor);
+
+        mat4.scale(incScaling, incScaling, amountVec);
+
+        // Shift the center back again
+        mat4.translate(incScaling, incScaling, vec3.sub(vec3.create(), vec3.create(), anchor));
+
+        this.setScale(mat4.multiply(mat4.create(), this.getScale(), incScaling));
+
+        return this;
+    }
+
+    /**
+     * Rotates the node by the specified amount about the axis defined by two constrained points.
+     *
+     * @param {number} degrees The amount to rotate, in degrees.
+     * @returns {Node} The current node, for method chaining.
+     */
+    public rotate(degrees: number): Node {
+        const constrainedPoints: vec3[] = [...this.held];
+
+        // If the node is attached to a parent node with an anchor, add it to the list of
+        // constrained points.
+        if (this.anchor !== null) {
+            constrainedPoints.push(this.anchor);
+        }
+
+        if (constrainedPoints.length !== 2) {
+            throw new Error('Two points needs to be held to know which axis to rotate about!');
+        }
+
+        const anchor = vec3ToPoint(constrainedPoints[0]);
+        const held = vec3ToPoint(constrainedPoints[1]);
+        const scaleMatrix = this.getScale();
+
+        // Rotation gets applied before scale, so we want to undo this node's scale before
+        // calculating the new rotation
+        vec4.transformMat4(anchor, anchor, scaleMatrix);
+        vec4.transformMat4(held, held, scaleMatrix);
+
+        // Compute the axis between the two constrained points
+        const heldAxis = vec4.sub(vec4.create(), held, anchor);
+        vec4.normalize(heldAxis, heldAxis);
+
+        // Move the center of rotation to the anchor
+        const incRotation = mat4.fromTranslation(mat4.create(), vec3From4(anchor));
+
+        // Add a rotation equal to the shortest rotation from the vector of the anchor to the grab
+        // point to the vector from the anchor to the target point
+        mat4.multiply(
+            incRotation,
+            mat4.fromRotation(mat4.create(), glMatrix.toRadian(degrees), vec3From4(heldAxis)),
+            incRotation
+        );
+
+        // Shift the center back again
+        mat4.translate(
+            incRotation,
+            incRotation,
+            vec3.sub(vec3.create(), vec3.create(), vec3From4(anchor))
+        );
+
+        this.setRotation(mat4.multiply(mat4.create(), this.getRotation(), incRotation));
 
         return this;
     }

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -56,6 +56,7 @@ const bone = Armature.define((root: Node) => {
     root.createPoint('base', { x: 0, y: 0, z: 0 });
     root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
     root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', { x: 1, y: 0, z: 0 });
 });
 
 const treeGen = Armature.generator();
@@ -63,13 +64,19 @@ const tree = treeGen
     .define('branch', 1, (root: Point) => {
         const node = bone();
         node.point('base').stickTo(root);
-        const theta = Math.random() * 45;
-        const phi = Math.random() * 360;
-        node.setRotation(Matrix.fromQuat4(Quaternion.fromEuler(theta, phi, 0)));
-        node.setScale(Matrix.fromScaling({ x: 0.8, y: 0.8, z: 0.8 })); // Shrink a bit
+
+        node
+            .hold(node.point('tip'))
+            .rotate(Math.random() * 360)
+            .release();
+        node
+            .hold(node.point('handle'))
+            .rotate(Math.random() * 90 - 45)
+            .release();
+        node.scale(0.8); // Shrink a bit
 
         const trunk = node.point('mid').attach(branchShape);
-        trunk.setScale(Matrix.fromScaling({ x: 0.2, y: 1, z: 0.2 }));
+        trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
         // branching factor of 2
         treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
@@ -83,8 +90,7 @@ const tree = treeGen
     })
     .define('leaf', 1, (root: Point) => {
         const leaf = root.attach(leafSphere);
-        const scale = Math.random() * 0.5 + 0.5;
-        leaf.setScale(Matrix.fromScaling({ x: scale, y: scale, z: scale }));
+        leaf.scale(Math.random() * 0.5 + 0.5);
     })
     .generate({ start: 'branch', depth: 15 });
 

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -254,6 +254,42 @@ describe('Node', () => {
         });
     });
 
+    describe('scale', () => {
+        it('scales by the given amount', () => {
+            const node = bone();
+            node.scale(2);
+
+            const point = vec4.fromValues(0, 1, 0, 1);
+            vec4.transformMat4(point, point, node.localToGlobalTransform());
+            expect(point).toEqualVec4(vec4.fromValues(0, 2, 0, 1));
+        });
+
+        it('scales about a point', () => {
+            const node = bone();
+            node.hold(node.point('tip')).scale(2);
+
+            const point = vec4.fromValues(0, 0, 0, 1);
+            vec4.transformMat4(point, point, node.localToGlobalTransform());
+            expect(point).toEqualVec4(vec4.fromValues(0, -1, 0, 1));
+        });
+    });
+
+    describe('rotate', () => {
+        it('rotates about an axis', () => {
+            const node = bone();
+
+            node
+                .hold(node.point('base'))
+                .hold(node.point('tip'))
+                .rotate(90)
+                .release();
+
+            const point = vec4.fromValues(1, 0, 0, 1);
+            vec4.transformMat4(point, point, node.localToGlobalTransform());
+            expect(point).toEqualVec4(vec4.fromValues(0, 0, -1, 1));
+        });
+    });
+
     describe('pointAt', () => {
         it('rotates a node about an axis', () => {
             const node = bone();


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/90

The tree example no longer needs quaternions and matrices!