### PR TITLE
Add method to destroy resources

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -87,6 +87,7 @@ export class Node {
         Node.bone.verticesBuffer = undefined;
         Node.bone.normalsBuffer = undefined;
         Node.bone.indicesBuffer = undefined;
+        Node.bone.colorsBuffer = undefined;
     }
 
     public createPoint(name: string, positionCoord: coord) {

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -83,6 +83,12 @@ export class Node {
         return cloned;
     }
 
+    public static invalidateBuffers() {
+        Node.bone.verticesBuffer = undefined;
+        Node.bone.normalsBuffer = undefined;
+        Node.bone.indicesBuffer = undefined;
+    }
+
     public createPoint(name: string, positionCoord: coord) {
         const position = Mapper.coordToVector(positionCoord);
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -120,6 +120,7 @@ export class Renderer {
 
     public destroy() {
         this.regl.destroy();
+        Node.invalidateBuffers();
     }
 
     public draw(

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -118,6 +118,10 @@ export class Renderer {
         this.drawAxes = createDrawAxes(this.regl);
     }
 
+    public destroy() {
+        this.regl.destroy();
+    }
+
     public draw(
         objects: Node[],
         debug: DebugParams = { drawAxes: false, drawArmatureBones: false }


### PR DESCRIPTION
In the editor, we need the ability to invalidate old webgl references for when we swap out an old canvas with a new one.