### PR TITLE
Update debug settings to be more useful

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -134,7 +134,6 @@ export class Renderer {
                 const childObjects = node.traverse(
                     mat4.create(),
                     mat3.create(),
-                    true,
                     debug.drawArmatureBones === true
                 );
 
@@ -301,8 +300,13 @@ export class Renderer {
                 vec4.transformMat4(vector, vector, this.camera.getTransform());
 
                 // Scale them and place them in the lower left corner of the screen
-                vec4.scale(vector, vector, Math.min(this.width, this.height) * 0.05);
-                vec4.add(vector, vector, [this.width * -0.25, this.height * -0.25, -500, 1]);
+                vec4.scale(vector, vector, 20);
+                vec4.add(vector, vector, [
+                    this.width * -0.3,
+                    this.height * -0.3,
+                    -Math.min(this.width, this.height),
+                    1
+                ]);
 
                 // Project them into 2D coordinates
                 vec4.transformMat4(vector, vector, this.projectionMatrix);

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -537,12 +537,8 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(1, 0, 1, 1);
 
-            const renderObjects: RenderObject[] = root.traverse(
-                mat4.create(),
-                mat3.create(),
-                true,
-                false
-            ).geometry;
+            const renderObjects: RenderObject[] = root.traverse(mat4.create(), mat3.create(), false)
+                .geometry;
 
             expect(renderObjects.length).toBe(1);
 
@@ -574,12 +570,8 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(0, 1, 0, 1);
 
-            const renderObjects: RenderObject[] = root.traverse(
-                mat4.create(),
-                mat3.create(),
-                true,
-                false
-            ).geometry;
+            const renderObjects: RenderObject[] = root.traverse(mat4.create(), mat3.create(), false)
+                .geometry;
 
             expect(renderObjects.length).toBe(1);
 
@@ -589,16 +581,8 @@ describe('Node', () => {
         });
 
         it('shows bones when asked', () => {
-            const geometry: BakedGeometry = {
-                vertices: Float32Array.from([]),
-                normals: Float32Array.from([]),
-                indices: Int16Array.from([]),
-                colors: Float32Array.from([])
-            };
-            const geometryChild = new GeometryNode(geometry);
-            const root = new Node([geometryChild]);
-
-            geometryChild.setPosition({ x: 1, y: 1, z: 0 });
+            const root = bone();
+            root.scale(2);
 
             /**
              * The bone should start at the root position (0, 0, 0) and stretch to the base of the
@@ -611,18 +595,27 @@ describe('Node', () => {
             const boneSpaceTip = vec4.fromValues(1, 0, 0, 1);
 
             const expectedWorldSpaceBase = vec4.fromValues(0, 0, 0, 1);
-            const expectedWorldSpaceTip = vec4.fromValues(1, 1, 0, 1);
+            const expectedWorldSpaceTip = vec4.fromValues(0, 2, 0, 1);
 
-            const bones: RenderObject[] = root.traverse(mat4.create(), mat3.create(), true, true)
-                .bones;
-            expect(bones.length).toBe(1);
+            const bones: RenderObject[] = root.traverse(mat4.create(), mat3.create(), true).bones;
+            expect(bones.length).toBe(2);
 
+            // Check base and tip of bone 1
             const transformedBase = vec4.create();
             vec4.transformMat4(transformedBase, boneSpaceBase, bones[0].transform);
             expect(transformedBase).toEqualVec4(expectedWorldSpaceBase);
 
             const transformedTip = vec4.create();
             vec4.transformMat4(transformedTip, boneSpaceTip, bones[0].transform);
+            expect(transformedTip).toEqualVec4(
+                vec4.add(vec4.create(), expectedWorldSpaceBase, vec4.fromValues(1e-6, 0, 0, 0))
+            );
+
+            // Check base and tip of bone 2
+            vec4.transformMat4(transformedBase, boneSpaceBase, bones[1].transform);
+            expect(transformedBase).toEqualVec4(expectedWorldSpaceBase);
+
+            vec4.transformMat4(transformedTip, boneSpaceTip, bones[1].transform);
             expect(transformedTip).toEqualVec4(expectedWorldSpaceTip);
         });
     });


### PR DESCRIPTION
- Fixes the location of the crosshairs so it doesn't collapse in on itself when we render a small view in the editor
- Changes the way bones work. Instead of bones connecting the origin of a parent to the origin of a child, for each `Point` in a node, there is a bone connecting the origin to that point. This way, you can start with just a node and see the bone rendered, when before you would have to attach something to the bone in order to see it.