### PR TITLE
Initial SOSMC implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,11 @@
     "@types/jest": "~22.2.2",
     "@types/lodash": "^4.14.107",
     "@types/node": "~8.10.0",
-    "babel-polyfill": "^6.26.0",
+    "typescript": "~2.8.1",
     "gl-matrix": "^2.5.1",
     "lodash": "^4.17.10",
     "regl": "regl-project/regl",
     "ts-sinon": "^1.0.12",
-    "tslib": "~1.9.0",
-    "typescript": "~2.8.1"
+    "tslib": "~1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "@types/jest": "~22.2.2",
     "@types/lodash": "^4.14.107",
     "@types/node": "~8.10.0",
-    "typescript": "~2.8.1",
+    "babel-polyfill": "^6.26.0",
     "gl-matrix": "^2.5.1",
     "lodash": "^4.17.10",
     "regl": "regl-project/regl",
     "ts-sinon": "^1.0.12",
-    "tslib": "~1.9.0"
+    "tslib": "~1.9.0",
+    "typescript": "~2.8.1"
   }
 }

--- a/src/armature/Animation.ts
+++ b/src/armature/Animation.ts
@@ -191,7 +191,7 @@ export namespace Animation {
                 animation.lastTimeInCycle = 0;
 
                 // Clone the current node and apply the callback to generate the target state
-                const finalNode = Node.clone(animation.node);
+                const finalNode = animation.node.clone();
                 animation.to(finalNode);
 
                 // Extract the transformation from the modified node

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -1,7 +1,7 @@
 import { coord } from '../calder';
 import { vec3From4 } from '../math/utils';
 import { Mapper } from '../utils/mapper';
-import { GeneratorInstance } from './Generator';
+import { CostFn, GeneratorInstance } from './Generator';
 import { Model } from './Model';
 import { GeometryNode, Node } from './Node';
 
@@ -17,7 +17,15 @@ type Grid = {[key: string]: true};
 type AABB = {min: coord; max: coord};
 
 export namespace CostFunction {
-    export function forces(points: ForcePoint[]) {
+
+    /**
+     * Use points with positive and negative influence to control generation.
+     *
+     * @param {ForcePoint[]} points The points of influence, where negative influence means the
+     * point reduces the overall cost when nodes get close.
+     * @returns {CostFn} The resulting cost function.
+     */
+    export function forces(points: ForcePoint[]): CostFn {
         const vectors = points.map((forcePoint: ForcePoint) => {
             return {
                 vector: Mapper.coordToVector(forcePoint.point),
@@ -26,19 +34,32 @@ export namespace CostFunction {
         });
 
         return (instance: GeneratorInstance, added: GeometryNode[]) => {
+            // For each added shape and each influence point, add the resulting cost to the
+            // instance's existing cost.
             return added.reduce((sum: number, node: GeometryNode) => {
                 const localToGlobalTransform = node.localToGlobalTransform();
                 const globalPosition = vec3From4(vec4.transformMat4(vec4.create(), vec4.fromValues(0, 0, 0, 1), localToGlobalTransform));
 
                 return vectors.reduce((total: number, point: {vector: vec3; influence: number}) => {
+
+                    // Add cost relative to the point's influence, and inversely proportional
+                    // to the distance to the point
                     return total + point.influence / vec3.length(vec3.sub(vec3.create(), point.vector, globalPosition));
                 }, sum);
             }, instance.getCost());
         }
     }
 
-    export function fillVolume(model: Model, cellSize: number) {
-        const instanceGrids = new Map<GeneratorInstance, Grid>();
+    /**
+     * Creates a cost function based on how much of a target volume a shape fills.
+     *
+     * @param {Model} targetModel The model whose shape we try to fill.
+     * @param {number} cellSize How big each cell in the volume grid should be.
+     * @returns {CostFn} The resulting cost function.
+     */
+    export function fillVolume(targetModel: Model, cellSize: number): CostFn {
+        // A grid uses a string as a key because otherwise it would use object equality on points,
+        // which we don't want. This function makes a string key from a point.
         const makeKey = (point: coord) => {
             const keyX = Math.round(point.x / cellSize);
             const keyY = Math.round(point.y / cellSize);
@@ -47,6 +68,8 @@ export namespace CostFunction {
             return `${keyX},${keyY},${keyZ}`;
         }
 
+        // Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
+        // and a max corner.
         const makeAABB = (node: GeometryNode) => {
             const localToGlobalTransform = node.localToGlobalTransform();
             const min = {x: Infinity, y: Infinity, z: Infinity};
@@ -71,6 +94,7 @@ export namespace CostFunction {
             return {min, max};
         };
 
+        // Check whether a point is inside an axis-aligned bounding box
         const pointInAABB = (point: coord, aabb: AABB) => {
             return (
                 point.x >= aabb.min.x && point.x <= aabb.max.x &&
@@ -79,19 +103,21 @@ export namespace CostFunction {
             );
         };
 
+        // For each node in the target model, find its bounding box
         const targetAABBs: AABB[] = [];
-        model.nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
+        targetModel.nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
             targetAABBs.push(makeAABB(node));
         }));
 
-        return (instance: GeneratorInstance, added: GeometryNode[]) => {
-            if (!instanceGrids.has(instance)) {
-                instanceGrids.set(instance, {});
-            }
-            const grid = <Grid>instanceGrids.get(instance);
+        return (instance: GeneratorInstance, _: GeometryNode[]) => {
+            // TODO: Cache the grid for each instance so that we don't need to recompute the
+            // whole thing each time. This is difficult in the same way that having a model
+            // supporting efficient copy-and-add is difficult.
+            const grid: Grid = {};
+
             let incrementalCost = 0;
 
-            added.forEach((node: GeometryNode) => {
+            instance.getModel().nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
                 // 1. Find axis-aligned bounding box in world coordinate
                 const addedAABB = makeAABB(node);
 
@@ -101,6 +127,8 @@ export namespace CostFunction {
                         range(target.min.y, target.max.y, cellSize).forEach((y: number) => {
                             range(target.min.z, target.max.z, cellSize).forEach((z: number) => {
                                 const key = makeKey({x, y, z});
+
+                                // Update grid and incremental cost
                                 if (!grid[key] && pointInAABB({x, y, z}, addedAABB)) {
                                     grid[key] = true;
                                     incrementalCost -= 1;
@@ -109,7 +137,7 @@ export namespace CostFunction {
                         });
                     });
                 });
-            });
+            }));
 
             return instance.getCost() + incrementalCost;
         }

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -80,9 +80,9 @@ export namespace CostFunction {
         // A grid uses a string as a key because otherwise it would use object equality on points,
         // which we don't want. This function makes a string key from a point.
         const makeKey = (point: vec4) => {
-            const keyX = Math.round(point[0] / cellSize);
-            const keyY = Math.round(point[1] / cellSize);
-            const keyZ = Math.round(point[2] / cellSize);
+            const keyX = Math.floor(point[0] / cellSize);
+            const keyY = Math.floor(point[1] / cellSize);
+            const keyZ = Math.floor(point[2] / cellSize);
 
             return `${keyX},${keyY},${keyZ}`;
         };
@@ -144,7 +144,8 @@ export namespace CostFunction {
                             grid[point] = true;
 
                             // If this point was in the target region, reduce the cost
-                            incrementalCost += targetCoords[point] ? -1 : 0;
+                            incrementalCost += cellSize * cellSize * cellSize *
+                                (targetCoords[point] ? -1 : 1);
                         }
                     });
                 })

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -35,9 +35,11 @@ export namespace CostFunction {
         return (instance: GeneratorInstance, added: Node[]) => {
             // Out of the added nodes, just get the geometry nodes
             const addedGeometry: GeometryNode[] = [];
-            added.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
-                addedGeometry.push(node);
-            }));
+            added.forEach((n: Node) =>
+                n.geometryCallback((node: GeometryNode) => {
+                    addedGeometry.push(node);
+                })
+            );
 
             // For each added shape and each influence point, add the resulting cost to the
             // instance's existing cost.
@@ -91,8 +93,16 @@ export namespace CostFunction {
         // and a max corner.
         const worldSpaceAABB = (node: GeometryNode) => {
             const localToGlobalTransform = node.localToGlobalTransform();
-            const min = vec4.transformMat4(vec4.create(), node.geometry.aabb.min, localToGlobalTransform);
-            const max = vec4.transformMat4(vec4.create(), node.geometry.aabb.max, localToGlobalTransform);
+            const min = vec4.transformMat4(
+                vec4.create(),
+                node.geometry.aabb.min,
+                localToGlobalTransform
+            );
+            const max = vec4.transformMat4(
+                vec4.create(),
+                node.geometry.aabb.max,
+                localToGlobalTransform
+            );
 
             return { min, max };
         };
@@ -100,16 +110,24 @@ export namespace CostFunction {
         const pointsInAABB = (aabb: AABB) => {
             const points: string[] = [];
             const point = vec4.fromValues(0, 0, 0, 1);
-            range(Math.floor(aabb.min[0]), Math.ceil(aabb.max[0]), cellSize).forEach((x: number) => {
-                range(Math.floor(aabb.min[1]), Math.ceil(aabb.max[1]), cellSize).forEach((y: number) => {
-                    range(Math.floor(aabb.min[2]), Math.ceil(aabb.max[2]), cellSize).forEach((z: number) => {
-                        point[0] = x;
-                        point[1] = y;
-                        point[2] = z;
-                        points.push(makeKey(point));
-                    });
-                });
-            });
+            range(Math.floor(aabb.min[0]), Math.ceil(aabb.max[0]), cellSize).forEach(
+                (x: number) => {
+                    range(Math.floor(aabb.min[1]), Math.ceil(aabb.max[1]), cellSize).forEach(
+                        (y: number) => {
+                            range(
+                                Math.floor(aabb.min[2]),
+                                Math.ceil(aabb.max[2]),
+                                cellSize
+                            ).forEach((z: number) => {
+                                point[0] = x;
+                                point[1] = y;
+                                point[2] = z;
+                                points.push(makeKey(point));
+                            });
+                        }
+                    );
+                }
+            );
 
             return points;
         };
@@ -118,7 +136,9 @@ export namespace CostFunction {
         const targetCoords: Grid = {};
         targetModel.nodes.forEach((n: Node) =>
             n.geometryCallback((node: GeometryNode) => {
-                pointsInAABB(worldSpaceAABB(node)).forEach((point: string) => targetCoords[point] = true);
+                pointsInAABB(worldSpaceAABB(node)).forEach(
+                    (point: string) => (targetCoords[point] = true)
+                );
             })
         );
 
@@ -127,11 +147,13 @@ export namespace CostFunction {
             // added to the end of a model's node list, if n nodes are new in the current model
             // compared to its parent, then the parent grid will be indexed by the nth-from-last
             // node in the current model's node list.
-            const parentGrid = gridCache.get(instance.getModel().nodes[instance.getModel().nodes.length - 1 - added.length]);
+            const parentGrid = gridCache.get(
+                instance.getModel().nodes[instance.getModel().nodes.length - 1 - added.length]
+            );
 
             // If the parent grid does exist, we want to start from the same grid as the
             // parent, and then add to it
-            const grid = parentGrid === undefined ? {} : {...parentGrid};
+            const grid = parentGrid === undefined ? {} : { ...parentGrid };
 
             let incrementalCost = 0;
 
@@ -144,8 +166,8 @@ export namespace CostFunction {
                             grid[point] = true;
 
                             // If this point was in the target region, reduce the cost
-                            incrementalCost += cellSize * cellSize * cellSize *
-                                (targetCoords[point] ? -1 : 1);
+                            incrementalCost +=
+                                cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1);
                         }
                     });
                 })

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -2,14 +2,19 @@ import { coord } from '../calder';
 import { vec3From4 } from '../math/utils';
 import { Mapper } from '../utils/mapper';
 import { GeneratorInstance } from './Generator';
-import { GeometryNode } from './Node';
+import { Model } from './Model';
+import { GeometryNode, Node } from './Node';
 
 import {vec3, vec4} from 'gl-matrix';
+import {range} from 'lodash';
 
 export type ForcePoint = {
     point: coord;
     influence: number;
 };
+
+type Grid = {[key: string]: true};
+type AABB = {min: coord; max: coord};
 
 export namespace CostFunction {
     export function forces(points: ForcePoint[]) {
@@ -29,6 +34,84 @@ export namespace CostFunction {
                     return total + point.influence / vec3.length(vec3.sub(vec3.create(), point.vector, globalPosition));
                 }, sum);
             }, instance.getCost());
+        }
+    }
+
+    export function fillVolume(model: Model, cellSize: number) {
+        const instanceGrids = new Map<GeneratorInstance, Grid>();
+        const makeKey = (point: coord) => {
+            const keyX = Math.round(point.x / cellSize);
+            const keyY = Math.round(point.y / cellSize);
+            const keyZ = Math.round(point.z / cellSize);
+
+            return `${keyX},${keyY},${keyZ}`;
+        }
+
+        const makeAABB = (node: GeometryNode) => {
+            const localToGlobalTransform = node.localToGlobalTransform();
+            const min = {x: Infinity, y: Infinity, z: Infinity};
+            const max = {x: -Infinity, y: -Infinity, z: -Infinity};
+            range(0, node.geometry.vertices.length, 3).forEach((i: number) => {
+                const globalPosition = vec3From4(vec4.transformMat4(vec4.create(), vec4.fromValues(
+                    node.geometry.vertices[i],
+                    node.geometry.vertices[i+1],
+                    node.geometry.vertices[i+2],
+                    1
+                ), localToGlobalTransform));
+
+                min.x = Math.min(min.x, globalPosition[0]);
+                min.y = Math.min(min.x, globalPosition[1]);
+                min.z = Math.min(min.x, globalPosition[2]);
+
+                max.x = Math.max(max.x, globalPosition[0]);
+                max.y = Math.max(max.x, globalPosition[1]);
+                max.z = Math.max(max.x, globalPosition[2]);
+            });
+
+            return {min, max};
+        };
+
+        const pointInAABB = (point: coord, aabb: AABB) => {
+            return (
+                point.x >= aabb.min.x && point.x <= aabb.max.x &&
+                point.y >= aabb.min.y && point.y <= aabb.max.y &&
+                point.z >= aabb.min.z && point.z <= aabb.max.z
+            );
+        };
+
+        const targetAABBs: AABB[] = [];
+        model.nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
+            targetAABBs.push(makeAABB(node));
+        }));
+
+        return (instance: GeneratorInstance, added: GeometryNode[]) => {
+            if (!instanceGrids.has(instance)) {
+                instanceGrids.set(instance, {});
+            }
+            const grid = <Grid>instanceGrids.get(instance);
+            let incrementalCost = 0;
+
+            added.forEach((node: GeometryNode) => {
+                // 1. Find axis-aligned bounding box in world coordinate
+                const addedAABB = makeAABB(node);
+
+                // 2. Fill bounding box cells in grid
+                targetAABBs.forEach((target: AABB) => {
+                    range(target.min.x, target.max.x, cellSize).forEach((x: number) => {
+                        range(target.min.y, target.max.y, cellSize).forEach((y: number) => {
+                            range(target.min.z, target.max.z, cellSize).forEach((z: number) => {
+                                const key = makeKey({x, y, z});
+                                if (!grid[key] && pointInAABB({x, y, z}, addedAABB)) {
+                                    grid[key] = true;
+                                    incrementalCost -= 1;
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+
+            return instance.getCost() + incrementalCost;
         }
     }
 }

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -24,8 +24,8 @@ export namespace CostFunction {
      * point reduces the overall cost when nodes get close.
      * @returns {CostFn} The resulting cost function.
      */
-    export function forces(points: ForcePoint[]): CostFn {
-        const vectors = points.map((forcePoint: ForcePoint) => {
+    export function forces(forcePoints: ForcePoint[]): CostFn {
+        const vectors = forcePoints.map((forcePoint: ForcePoint) => {
             return {
                 vector: Mapper.coordToVector(forcePoint.point),
                 influence: forcePoint.influence

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -69,6 +69,24 @@ export namespace CostFunction {
         };
     }
 
+    // Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
+    // and a max corner.
+    const worldSpaceAABB = (node: GeometryNode) => {
+        const localToGlobalTransform = node.localToGlobalTransform();
+        const min = vec4.transformMat4(
+            vec4.create(),
+            node.geometry.aabb.min,
+            localToGlobalTransform
+        );
+        const max = vec4.transformMat4(
+            vec4.create(),
+            node.geometry.aabb.max,
+            localToGlobalTransform
+        );
+
+        return { min, max };
+    };
+
     /**
      * Creates a cost function based on how much of a target volume a shape fills.
      *
@@ -89,24 +107,7 @@ export namespace CostFunction {
             return `${keyX},${keyY},${keyZ}`;
         };
 
-        // Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
-        // and a max corner.
-        const worldSpaceAABB = (node: GeometryNode) => {
-            const localToGlobalTransform = node.localToGlobalTransform();
-            const min = vec4.transformMat4(
-                vec4.create(),
-                node.geometry.aabb.min,
-                localToGlobalTransform
-            );
-            const max = vec4.transformMat4(
-                vec4.create(),
-                node.geometry.aabb.max,
-                localToGlobalTransform
-            );
-
-            return { min, max };
-        };
-
+        // Returns the points that are in a world-space AABB.
         const pointsInAABB = (aabb: AABB) => {
             const points: string[] = [];
             const point = vec4.fromValues(0, 0, 0, 1);

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -1,0 +1,34 @@
+import { coord } from '../calder';
+import { vec3From4 } from '../math/utils';
+import { Mapper } from '../utils/mapper';
+import { GeneratorInstance } from './Generator';
+import { GeometryNode } from './Node';
+
+import {vec3, vec4} from 'gl-matrix';
+
+export type ForcePoint = {
+    point: coord;
+    influence: number;
+};
+
+export namespace CostFunction {
+    export function forces(points: ForcePoint[]) {
+        const vectors = points.map((forcePoint: ForcePoint) => {
+            return {
+                vector: Mapper.coordToVector(forcePoint.point),
+                influence: forcePoint.influence
+            };
+        });
+
+        return (instance: GeneratorInstance, added: GeometryNode[]) => {
+            return added.reduce((sum: number, node: GeometryNode) => {
+                const localToGlobalTransform = node.localToGlobalTransform();
+                const globalPosition = vec3From4(vec4.transformMat4(vec4.create(), vec4.fromValues(0, 0, 0, 1), localToGlobalTransform));
+
+                return vectors.reduce((total: number, point: {vector: vec3; influence: number}) => {
+                    return total + point.influence / vec3.length(vec3.sub(vec3.create(), point.vector, globalPosition));
+                }, sum);
+            }, instance.getCost());
+        }
+    }
+}

--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -67,7 +67,10 @@ export class GeneratorInstance {
         let addedShape = false;
 
         while (!addedShape && this.spawnPoints.length > 0) {
-            const spawnPoint = this.spawnPoints.splice(Math.floor(this.random() * this.spawnPoints.length), 1)[0];
+            const spawnPoint = this.spawnPoints.splice(
+                Math.floor(this.random() * this.spawnPoints.length),
+                1
+            )[0];
             const onAddCallback = (node: Node) => {
                 addedShape = true;
                 incrementalCost += this.costFn(node);
@@ -172,11 +175,7 @@ export class Generator {
      * geometry at that point. Call `addDetail` in the function to spawn more.
      * @returns {Generator} The current generator, so that more methods can be chained.
      */
-    public defineWeighted(
-        name: string,
-        weight: number,
-        generator: GeneratorFn
-    ): Generator {
+    public defineWeighted(name: string, weight: number, generator: GeneratorFn): Generator {
         // Make a component for the given name if one doesn't already exist
         if (this.rules[name] === undefined) {
             this.rules[name] = { totalWeight: 0, definitions: [] };
@@ -197,7 +196,12 @@ export class Generator {
         return instance.getModel();
     }
 
-    public generateSOMC(params: { start: string; depth?: number; samples?: number; costFn: CostFn }): Model {
+    public generateSOMC(params: {
+        start: string;
+        depth?: number;
+        samples?: number;
+        costFn: CostFn;
+    }): Model {
         const { start, depth = 10, samples = 50, costFn } = params;
         let instances = range(samples).map(() => new GeneratorInstance(this, costFn));
 
@@ -211,7 +215,7 @@ export class Generator {
             // Step 2: if there will be more iterations, do a weighted resample
             if (iteration + 1 !== depth) {
                 const total = instances.reduce((accum: number, instance: GeneratorInstance) => {
-                    return accum + 1/instance.getCost();
+                    return accum + 1 / instance.getCost();
                 }, 0);
                 instances = instances.map(() => {
                     let sample = this.random() * total;
@@ -219,7 +223,7 @@ export class Generator {
                     let i = 0;
                     do {
                         picked = instances[i];
-                        sample -= 1/picked.getCost();
+                        sample -= 1 / picked.getCost();
                         i += 1;
                     } while (sample > 0);
 
@@ -228,7 +232,9 @@ export class Generator {
             }
         });
 
-        return (<GeneratorInstance> minBy(instances, (instance: GeneratorInstance) => instance.getCost())).getModel();
+        return (<GeneratorInstance>minBy(instances, (instance: GeneratorInstance) =>
+            instance.getCost()
+        )).getModel();
     }
 
     /**

--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -307,13 +307,13 @@ export class Generator {
                     // Subtract each instance's weight from the generated number until it reaches
                     // zero. The instance to make it reach zero is the instance corresponding to
                     // the random number we generated.
-                    let picked: GeneratorInstance | null = null;
+                    let picked: GeneratorInstance = instances[0];
                     let i = 0;
-                    do {
+                    while (sample > 0) {
                         picked = instances[i];
                         sample -= 1 / Math.exp(picked.getCost());
                         i += 1;
-                    } while (sample > 0);
+                    }
 
                     // Make a new copy of the picked instance that can be grown independently from
                     // the original version.

--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -106,7 +106,7 @@ export class GeneratorInstance {
     /**
      * Grows this instance, if possible, until a new shape is added.
      */
-    public advance() {
+    public growIfPossible() {
         const originalLength = this.model.nodes.length;
 
         while (this.model.nodes.length === originalLength && this.spawnPoints.length > 0) {
@@ -144,7 +144,7 @@ export class GeneratorInstance {
 
         // Run `depth` rounds of generation
         range(depth).forEach(() => {
-            this.advance();
+            this.growIfPossible();
         });
     }
 
@@ -279,7 +279,7 @@ export class Generator {
 
         range(depth).forEach((iteration: number) => {
             // Step 1: grow samples
-            instances.forEach((instance: GeneratorInstance) => instance.advance());
+            instances.forEach((instance: GeneratorInstance) => instance.growIfPossible());
 
             // Step 2: if there will be more iterations, do a weighted resample
             if (iteration + 1 !== depth) {

--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -125,9 +125,11 @@ export class GeneratorInstance {
 
         // Out of the `Node`s that were generated, get the ones that were `GeometryNode`s
         const addedGeometry: GeometryNode[] = [];
-        this.model.nodes.slice(originalLength).forEach((node: Node) => node.geometryCallback((g: GeometryNode) => {
-            addedGeometry.push(g);
-        }));
+        this.model.nodes.slice(originalLength).forEach((node: Node) =>
+            node.geometryCallback((g: GeometryNode) => {
+                addedGeometry.push(g);
+            })
+        );
 
         // Recompute the cost
         this.cost = this.costFn(this, addedGeometry);
@@ -289,10 +291,13 @@ export class Generator {
                 // picked for the next generation. A low cost should give a high weight, and a high
                 // cost should give a low weight.
 
-                const totalWeight = instances.reduce((accum: number, instance: GeneratorInstance) => {
-                    // 1 / e^x means that lower (even negative) costs get a higher weight
-                    return accum + 1 / Math.exp(instance.getCost());
-                }, 0);
+                const totalWeight = instances.reduce(
+                    (accum: number, instance: GeneratorInstance) => {
+                        // 1 / e^x means that lower (even negative) costs get a higher weight
+                        return accum + 1 / Math.exp(instance.getCost());
+                    },
+                    0
+                );
 
                 // Re-pick instances from the previous set, according to their weights
                 instances = instances.map(() => {

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -1,0 +1,65 @@
+import { mat3, mat4 } from 'gl-matrix';
+
+import { Node } from './Node';
+import { NodeRenderObject } from './NodeRenderObject';
+
+type RenderInfo = { currentMatrix: mat4; currentNormalMatrix: mat3; objects: NodeRenderObject };
+
+export class Model {
+    public readonly nodes: Node[];
+
+    constructor(nodes: Node[] = []) {
+        this.nodes = nodes;
+    }
+
+    public static create(...nodes: Node[]): Model {
+        return new Model(nodes);
+    }
+
+    public clone() {
+        return new Model([...this.nodes]);
+    }
+
+    public add(node: Node): Node {
+        this.nodes.push(node);
+
+        return node;
+    }
+
+    public root(): Node {
+        return this.nodes[0];
+    }
+
+    public traverse(makeBones: boolean): NodeRenderObject {
+        const renderCache: Map<Node, RenderInfo> = new Map<Node, RenderInfo>();
+        const renderQueue = [...this.nodes];
+
+        const result: NodeRenderObject = {geometry: [], bones: []};
+
+        while (renderQueue.length > 0) {
+            const node = <Node> renderQueue.pop();
+
+            if (renderCache.has(node)) {
+                continue;
+            }
+
+            if (node.parent === null) {
+                const info = node.traverse(mat4.create(), mat3.create(), makeBones);
+                renderCache.set(node, info);
+                result.geometry.push(...info.objects.geometry);
+                result.bones.push(...info.objects.bones);
+            } else if (renderCache.has(node.parent)) {
+                const { currentMatrix, currentNormalMatrix } = <RenderInfo> renderCache.get(node.parent);
+                const info = node.traverse(currentMatrix, currentNormalMatrix, makeBones);
+                renderCache.set(node, info);
+                result.geometry.push(...info.objects.geometry);
+                result.bones.push(...info.objects.bones);
+            } else {
+                renderQueue.push(node.parent);
+                renderQueue.unshift(node);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -34,10 +34,10 @@ export class Model {
         const renderCache: Map<Node, RenderInfo> = new Map<Node, RenderInfo>();
         const renderQueue = [...this.nodes];
 
-        const result: NodeRenderObject = {geometry: [], bones: []};
+        const result: NodeRenderObject = { geometry: [], bones: [] };
 
         while (renderQueue.length > 0) {
-            const node = <Node> renderQueue.pop();
+            const node = <Node>renderQueue.pop();
 
             if (renderCache.has(node)) {
                 continue;
@@ -49,14 +49,15 @@ export class Model {
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
             } else if (renderCache.has(node.parent)) {
-                const { currentMatrix, currentNormalMatrix } = <RenderInfo> renderCache.get(node.parent);
+                const { currentMatrix, currentNormalMatrix } = <RenderInfo>renderCache.get(
+                    node.parent
+                );
                 const info = node.traverse(currentMatrix, currentNormalMatrix, makeBones);
                 renderCache.set(node, info);
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
             } else {
-                renderQueue.push(node.parent);
-                renderQueue.unshift(node);
+                renderQueue.push(node, node.parent);
             }
         }
 

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -12,7 +12,6 @@ type RenderInfo = { currentMatrix: mat4; currentNormalMatrix: mat3; objects: Nod
  * needing to be modified.
  */
 export class Model {
-
     /**
      * The collection of connected nodes.
      */
@@ -98,7 +97,6 @@ export class Model {
                 // Add to the result
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
-
             } else if (renderCache.has(node.parent)) {
                 // If the node's parent has already been rendered, we can read its transformation
                 // information from the cache
@@ -113,7 +111,6 @@ export class Model {
                 // Add to the result
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
-
             } else {
                 // Otherwise, we need to render the parent before the current node. Add both back
                 // to the list, but with the parent closer to the top, so that it gets rendered

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -91,7 +91,7 @@ export class Model {
      * geometry.
      * @returns NodeRenderObject The info needed by the renderer to visualize this model.
      */
-    public traverse(makeBones: boolean): NodeRenderObject {
+    public computeRenderInfo(makeBones: boolean): NodeRenderObject {
         // In order to render a child, we have to know its parent's transformation. We don't want
         // to recompute this any more times than we have to, so we keep a cache of this information
         // for each node in the form of a `RenderInfo`
@@ -111,7 +111,7 @@ export class Model {
 
             if (node.parent === null) {
                 // If the node has no parent, its parent transforms are identity matrices
-                const info = node.traverse(mat4.create(), mat3.create(), makeBones);
+                const info = node.computeRenderInfo(mat4.create(), mat3.create(), makeBones);
 
                 // Cache this info so it can be used for the node's children
                 renderCache.set(node, info);
@@ -125,7 +125,7 @@ export class Model {
                 const { currentMatrix, currentNormalMatrix } = <RenderInfo>renderCache.get(
                     node.parent
                 );
-                const info = node.traverse(currentMatrix, currentNormalMatrix, makeBones);
+                const info = node.computeRenderInfo(currentMatrix, currentNormalMatrix, makeBones);
 
                 // Cache this info so it can be used for the node's children
                 renderCache.set(node, info);

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -3,7 +3,22 @@ import { mat3, mat4 } from 'gl-matrix';
 import { Node } from './Node';
 import { NodeRenderObject } from './NodeRenderObject';
 
-type RenderInfo = { currentMatrix: mat4; currentNormalMatrix: mat3; objects: NodeRenderObject };
+type RenderInfo = {
+    /**
+     * The position transformation matrix for a node's coordinate space.
+     */
+    currentMatrix: mat4;
+
+    /**
+     * The normal transformation matrix for a node's coordinate space.
+     */
+    currentNormalMatrix: mat3;
+
+    /**
+     * The geometry and bones to be rendered from a node.
+     */
+    objects: NodeRenderObject;
+};
 
 /**
  * A set of connected armature nodes, enabling efficient creation of a copy that one can add to

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -78,6 +78,13 @@ export class Model {
     }
 
     /**
+     * @returns {Node} The most recently added node to the model.
+     */
+    public latest(): Node {
+        return this.nodes[this.nodes.length - 1];
+    }
+
+    /**
      * Walks through all the nodes in the model, generating buffers to send to the renderer.
      *
      * @param {boolean} makeBones Whether or not to generate buffers for bones in addition to

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -5,33 +5,78 @@ import { NodeRenderObject } from './NodeRenderObject';
 
 type RenderInfo = { currentMatrix: mat4; currentNormalMatrix: mat3; objects: NodeRenderObject };
 
+/**
+ * A set of connected armature nodes, enabling efficient creation of a copy that one can add to
+ * without modifying the original. Nodes have connections to the parent that they are connected
+ * to and not to their children, so new nodes can be added that refer to parents without the parents
+ * needing to be modified.
+ */
 export class Model {
+
+    /**
+     * The collection of connected nodes.
+     */
     public readonly nodes: Node[];
 
+    /**
+     * Creates a new model.
+     *
+     * @param {Node[]} nodes A set of nodes which, if passed in, are used to initialize the model.
+     */
     constructor(nodes: Node[] = []) {
         this.nodes = nodes;
     }
 
+    /**
+     * Creates a new model.
+     *
+     * @param {Node[]} nodes A set of nodes which, if passed in, are used to initialize the model.
+     * @returns {Model} The new model.
+     */
     public static create(...nodes: Node[]): Model {
         return new Model(nodes);
     }
 
+    /**
+     * @returns A copy of the current model that has all the same nodes, but can be added to.
+     */
     public clone() {
         return new Model([...this.nodes]);
     }
 
+    /**
+     * Adds a node to the model.
+     *
+     * @param {Node} node The node to add.
+     * @returns Node The added node, for convenience.
+     */
     public add(node: Node): Node {
         this.nodes.push(node);
 
         return node;
     }
 
+    /**
+     * @returns {Node} The first node added to the model, which is therefore the root node.
+     */
     public root(): Node {
         return this.nodes[0];
     }
 
+    /**
+     * Walks through all the nodes in the model, generating buffers to send to the renderer.
+     *
+     * @param {boolean} makeBones Whether or not to generate buffers for bones in addition to
+     * geometry.
+     * @returns NodeRenderObject The info needed by the renderer to visualize this model.
+     */
     public traverse(makeBones: boolean): NodeRenderObject {
+        // In order to render a child, we have to know its parent's transformation. We don't want
+        // to recompute this any more times than we have to, so we keep a cache of this information
+        // for each node in the form of a `RenderInfo`
         const renderCache: Map<Node, RenderInfo> = new Map<Node, RenderInfo>();
+
+        // Nodes yet to be added to the `NodeRenderObject` result.
         const renderQueue = [...this.nodes];
 
         const result: NodeRenderObject = { geometry: [], bones: [] };
@@ -44,19 +89,35 @@ export class Model {
             }
 
             if (node.parent === null) {
+                // If the node has no parent, its parent transforms are identity matrices
                 const info = node.traverse(mat4.create(), mat3.create(), makeBones);
+
+                // Cache this info so it can be used for the node's children
                 renderCache.set(node, info);
+
+                // Add to the result
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
+
             } else if (renderCache.has(node.parent)) {
+                // If the node's parent has already been rendered, we can read its transformation
+                // information from the cache
                 const { currentMatrix, currentNormalMatrix } = <RenderInfo>renderCache.get(
                     node.parent
                 );
                 const info = node.traverse(currentMatrix, currentNormalMatrix, makeBones);
+
+                // Cache this info so it can be used for the node's children
                 renderCache.set(node, info);
+
+                // Add to the result
                 result.geometry.push(...info.objects.geometry);
                 result.bones.push(...info.objects.bones);
+
             } else {
+                // Otherwise, we need to render the parent before the current node. Add both back
+                // to the list, but with the parent closer to the top, so that it gets rendered
+                // first.
                 renderQueue.push(node, node.parent);
             }
         }

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -98,12 +98,12 @@ export class Model {
         const renderCache: Map<Node, RenderInfo> = new Map<Node, RenderInfo>();
 
         // Nodes yet to be added to the `NodeRenderObject` result.
-        const renderQueue = [...this.nodes];
+        const renderStack = [...this.nodes];
 
         const result: NodeRenderObject = { geometry: [], bones: [] };
 
-        while (renderQueue.length > 0) {
-            const node = <Node>renderQueue.pop();
+        while (renderStack.length > 0) {
+            const node = <Node>renderStack.pop();
 
             if (renderCache.has(node)) {
                 continue;
@@ -137,7 +137,7 @@ export class Model {
                 // Otherwise, we need to render the parent before the current node. Add both back
                 // to the list, but with the parent closer to the top, so that it gets rendered
                 // first.
-                renderQueue.push(node, node.parent);
+                renderStack.push(node, node.parent);
             }
         }
 

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -487,7 +487,7 @@ export class Node {
      * The current node's transformation matrix is also returned so that additional `RenderObject`s
      * can be added to the result if needed without recomputing this matrix.
      */
-    public traverse(
+    public computeRenderInfo(
         parentMatrix: mat4,
         parentNormalMatrix: mat3,
         makeBones: boolean
@@ -883,12 +883,12 @@ export class GeometryNode extends Node {
      * @returns {NodeRenderObject} The geometry for this armature subtree, and possibly geometry
      * representing the armature itself.
      */
-    public traverse(
+    public computeRenderInfo(
         coordinateSpace: mat4,
         normalTransform: mat3,
         makeBones: boolean
     ): { currentMatrix: mat4; currentNormalMatrix: mat3; objects: NodeRenderObject } {
-        const { currentMatrix, currentNormalMatrix, objects } = super.traverse(
+        const { currentMatrix, currentNormalMatrix, objects } = super.computeRenderInfo(
             coordinateSpace,
             normalTransform,
             makeBones

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -471,24 +471,6 @@ export class Node {
     }
 
     /**
-     * Returns an array of `RenderObject`s denoting `GeometryNode`s
-     * transformations multiplied by the `coordinateSpace` parameter.
-     *
-     * @param {mat4} coordinateSpace The coordinate space this node resides in.
-     * @param {mat3} coordinateSpace The coordinate space this node resides in.
-     * @param {boolean} makeBones Whether or not the armature heirarchy should be visualized.
-     * @returns {NodeRenderObject} The geometry for this armature subtree, and possibly geometry
-     * representing the armature itself.
-     */
-    //public traverse(
-        //coordinateSpace: mat4,
-        //normalTransform: mat3,
-        //makeBones: boolean
-    //): NodeRenderObject {
-        //return this.traverseSelf(coordinateSpace, normalTransform, makeBones).objects;
-    //}
-
-    /**
      * Generates `RenderObject`s for this node's children, plus a bone for this node, if specified.
      * The current node's transformation matrix is also returned so that additional `RenderObject`s
      * can be added to the result if needed without recomputing this matrix.
@@ -504,24 +486,6 @@ export class Node {
         mat3.multiply(currentNormalMatrix, parentNormalMatrix, currentNormalMatrix);
 
         const objects: NodeRenderObject = { geometry: [], bones: [] };
-
-        //const objects: NodeRenderObject = this.children.reduce(
-            //(accum: NodeRenderObject, child: Node) => {
-                //const childRenderObject: NodeRenderObject = child.traverse(
-                    //currentMatrix,
-                    //currentNormalMatrix,
-                    //makeBones
-                //);
-
-                //// Merge the geometry and bones from each child into one long list of geometry and
-                //// one long list of bones for all children
-                //accum.geometry.push(...childRenderObject.geometry);
-                //accum.bones.push(...childRenderObject.bones);
-
-                //return accum;
-            //},
-            //{ geometry: [], bones: [] }
-        //);
 
         if (makeBones) {
             objects.bones.push(
@@ -884,9 +848,13 @@ export class GeometryNode extends Node {
      * @param {BakedGeometry} geometry
      * @param {Node[]} children
      */
-    constructor(geometry: BakedGeometry, parent: Node | null = null, position: vector3 = vec3.fromValues(0, 0, 0),
+    constructor(
+        geometry: BakedGeometry,
+        parent: Node | null = null,
+        position: vector3 = vec3.fromValues(0, 0, 0),
         rotation: matrix4 = mat4.create(),
-        scale: matrix4 = mat4.create()) {
+        scale: matrix4 = mat4.create()
+    ) {
         super(parent, position, rotation, scale);
         this.geometry = geometry;
     }
@@ -916,7 +884,7 @@ export class GeometryNode extends Node {
             normalTransform: currentNormalMatrix
         });
 
-        return {currentMatrix, currentNormalMatrix, objects};
+        return { currentMatrix, currentNormalMatrix, objects };
     }
 }
 

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -85,6 +85,8 @@ export class Node {
         return cloned;
     }
 
+    public geometryCallback(_: (node: GeometryNode) => void) {}
+
     public createPoint(name: string, positionCoord: coord) {
         const position = Mapper.coordToVector(positionCoord);
 
@@ -886,6 +888,10 @@ export class GeometryNode extends Node {
 
         return { currentMatrix, currentNormalMatrix, objects };
     }
+
+    public geometryCallback(callback: (node: GeometryNode) => void) {
+        callback(this);
+    }
 }
 
 /**
@@ -895,7 +901,6 @@ export class Point {
     public readonly node: Node;
     public readonly position: vec3;
     public readonly name: string;
-    private onAddCallbacks: ((node: Node) => void)[] = [];
 
     /**
      * @param {Node} node The node that this point is in the coordinate space of.
@@ -908,16 +913,6 @@ export class Point {
         this.name = name;
     }
 
-    public onAdd(callback: (node: Node) => void) {
-        this.onAddCallbacks.push(callback);
-    }
-
-    public removeOnAdd(callback: (node: Node) => void) {
-        this.onAddCallbacks = this.onAddCallbacks.filter((c: (node: Node) => void) => {
-            return c !== callback;
-        });
-    }
-
     /**
      * Attaches the current node to the specified target node at the given point.
      *
@@ -928,7 +923,6 @@ export class Point {
             throw new Error('Cannot attach a point to another point on the same node');
         }
         target.node.addChild(this.node);
-        target.runOnAddCallbacks(this.node);
         this.node.setAnchor(this.position);
         const vecSub = vec3.subtract(vec3.create(), target.position, this.position);
         this.node.setPosition(Mapper.vectorToCoord(vecSub));
@@ -945,14 +939,7 @@ export class Point {
         geometryNode.setAnchor(vec3.fromValues(0, 0, 0));
         geometryNode.setPosition(Mapper.vectorToCoord(this.position));
         this.node.addChild(geometryNode);
-        this.runOnAddCallbacks(geometryNode);
 
         return geometryNode;
-    }
-
-    protected runOnAddCallbacks(added: Node) {
-        this.onAddCallbacks.forEach((callback: (node: Node) => void) => {
-            callback(added);
-        });
     }
 }

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -45,8 +45,11 @@ export class Node {
                 [5, 1, 4]
             ])
         ),
-
-        material: defaultMaterial.bake()
+        material: defaultMaterial.bake(),
+        aabb: {
+            min: vec4.fromValues(0, -0.1, -0.1, 1),
+            max: vec4.fromValues(1, 0.1, 0.1, 1)
+        }
     };
 
     public parent: Node | null = null;

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -32,6 +32,7 @@ export * from './armature/Animation';
 export * from './armature/Armature';
 export * from './armature/Constraints';
 export * from './armature/Generator';
+export * from './armature/Model';
 export * from './armature/Node';
 
 /*****************************

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -31,6 +31,7 @@
 export * from './armature/Animation';
 export * from './armature/Armature';
 export * from './armature/Constraints';
+export * from './armature/Generator';
 export * from './armature/Node';
 
 /*****************************

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -31,6 +31,7 @@
 export * from './armature/Animation';
 export * from './armature/Armature';
 export * from './armature/Constraints';
+export * from './armature/CostFunction';
 export * from './armature/Generator';
 export * from './armature/Model';
 export * from './armature/Node';

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -94,7 +94,7 @@ treeGen
         instance.addDetail({ component: 'branch', at: root });
     });
 
-/*const tree = treeGen.generateSOMC({
+/*const tree = treeGen.generateSOSMC({
     start: 'branch',
     depth: 150,
     samples: 100,
@@ -109,7 +109,7 @@ const sphere = treeTarget.add(new GeometryNode(leafSphere));
 sphere.scale(4);
 sphere.moveTo({x: 5, y: 7, z: 0});
 
-const tree = treeGen.generateSOMC({
+const tree = treeGen.generateSOSMC({
     start: 'branch',
     depth: 150,
     samples: 100,

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -109,7 +109,7 @@ const sphere = treeTarget.add(new GeometryNode(leafSphere));
 //sphere.scale(4);
 sphere.moveTo({ x: 0, y: 3, z: 0 });
 const branch = treeTarget.add(new GeometryNode(branchShape));
-branch.scale({x: 0.2, y: 2, z: 0.2});
+branch.scale({ x: 0.2, y: 2, z: 0.2 });
 branch.moveTo({ x: 0, y: 1, z: 0 });
 
 const tree = treeGen.generateSOSMC({
@@ -119,7 +119,7 @@ const tree = treeGen.generateSOSMC({
     costFn: CostFunction.fillVolume(treeTarget, 0.2),
     onLastGeneration: (instances: GeneratorInstance[]) => {
         const result = <HTMLParagraphElement>document.createElement('p');
-        result.innerText = "Costs in final generation: ";
+        result.innerText = 'Costs in final generation: ';
         result.innerText += instances
             .map((instance: GeneratorInstance) => instance.getCost())
             .sort((a: number, b: number) => a - b)

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -21,7 +21,7 @@ const renderer: Renderer = new Renderer({
     height: 600,
     maxLights: 2,
     ambientLightColor: RGBColor.fromRGB(90, 90, 90),
-    backgroundColor: RGBColor.fromHex('#FF00FF')
+    backgroundColor: RGBColor.fromHex('#FFDDFF')
 });
 
 // Create light sources for the renderer
@@ -62,6 +62,7 @@ treeGen
     .define('branch', (root: Point, instance: GeneratorInstance) => {
         const node = instance.add(bone());
         node.point('base').stickTo(root);
+        node.scale(Math.random() * 0.4 + 0.9);
         node
             .hold(node.point('tip'))
             .rotate(Math.random() * 360)
@@ -105,19 +106,24 @@ treeGen
 
 const treeTarget = Model.create();
 const sphere = treeTarget.add(new GeometryNode(leafSphere));
-sphere.scale(5);
-sphere.moveTo({ x: 0, y: 10, z: 0 });
+//sphere.scale(4);
+sphere.moveTo({ x: 0, y: 3, z: 0 });
+const branch = treeTarget.add(new GeometryNode(branchShape));
+branch.scale({x: 0.2, y: 2, z: 0.2});
+branch.moveTo({ x: 0, y: 1, z: 0 });
 
 const tree = treeGen.generateSOSMC({
     start: 'branch',
-    depth: 300,
+    depth: 200,
     samples: 100,
     costFn: CostFunction.fillVolume(treeTarget, 0.2),
     onLastGeneration: (instances: GeneratorInstance[]) => {
         const result = <HTMLParagraphElement>document.createElement('p');
-        result.innerText = instances
+        result.innerText = "Costs in final generation: ";
+        result.innerText += instances
             .map((instance: GeneratorInstance) => instance.getCost())
             .sort((a: number, b: number) => a - b)
+            .map((cost: number) => Math.round(cost * 100) / 100)
             .join(', ');
         document.body.appendChild(result);
     }

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -4,6 +4,7 @@ import {
     Light,
     Material,
     Matrix,
+    Model,
     Node,
     Point,
     Quaternion,
@@ -58,7 +59,7 @@ const bone = Armature.define((root: Node) => {
 const treeGen = Armature.generator();
 treeGen
     .define('branch', (root: Point, instance: GeneratorInstance) => {
-        const node = bone();
+        const node = instance.add(bone());
         node.point('base').stickTo(root);
         node
             .hold(node.point('tip'))
@@ -70,7 +71,7 @@ treeGen
             .release();
         node.scale(0.8); // Shrink a bit
 
-        const trunk = node.point('mid').attach(branchShape);
+        const trunk = instance.add(node.point('mid').attach(branchShape));
         trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
         instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
@@ -83,8 +84,8 @@ treeGen
         instance.addDetail({ component: 'maybeBranch', at: root });
         instance.addDetail({ component: 'maybeBranch', at: root });
     })
-    .define('leaf', (root: Point, _: GeneratorInstance) => {
-        const leaf = root.attach(leafSphere);
+    .define('leaf', (root: Point, instance: GeneratorInstance) => {
+        const leaf = instance.add(root.attach(leafSphere));
         leaf.scale(Math.random() * 0.5 + 0.5);
     })
     .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
@@ -107,7 +108,7 @@ renderer.camera.lookAt({ x: 2, y: 2, z: -4 });
 let angle = 0;
 const draw = () => {
     angle += 0.5;
-    tree.setRotation(Matrix.fromQuat4(Quaternion.fromEuler(0, angle, 0)));
+    tree.root().setRotation(Matrix.fromQuat4(Quaternion.fromEuler(0, angle, 0)));
 
     return {
         objects: [tree],

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -118,7 +118,7 @@ const tree = treeGen.generateSOSMC({
     samples: 100,
     costFn: CostFunction.fillVolume(treeTarget, 0.2),
     onLastGeneration: (instances: GeneratorInstance[]) => {
-        const result = <HTMLParagraphElement>document.createElement('p');
+        const result = document.createElement('p');
         result.innerText = 'Costs in final generation: ';
         result.innerText += instances
             .map((instance: GeneratorInstance) => instance.getCost())

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -1,5 +1,6 @@
 import {
     Armature,
+    GeneratorInstance,
     Light,
     Material,
     Matrix,
@@ -56,7 +57,7 @@ const bone = Armature.define((root: Node) => {
 
 const treeGen = Armature.generator();
 treeGen
-    .define('branch', (root: Point) => {
+    .define('branch', (root: Point, instance: GeneratorInstance) => {
         const node = bone();
         node.point('base').stickTo(root);
         node
@@ -72,24 +73,26 @@ treeGen
         const trunk = node.point('mid').attach(branchShape);
         trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
-        treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+        instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
     })
-    .defineWeighted('branchOrLeaf', 1, (root: Point) => {
-        treeGen.addDetail({ component: 'leaf', at: root });
+    .defineWeighted('branchOrLeaf', 1, (root: Point, instance: GeneratorInstance) => {
+        instance.addDetail({ component: 'leaf', at: root });
     })
-    .defineWeighted('branchOrLeaf', 4, (root: Point) => {
-        treeGen.addDetail({ component: 'branch', at: root });
-        treeGen.addDetail({ component: 'maybeBranch', at: root });
-        treeGen.addDetail({ component: 'maybeBranch', at: root });
+    .defineWeighted('branchOrLeaf', 4, (root: Point, instance: GeneratorInstance) => {
+        instance.addDetail({ component: 'branch', at: root });
+        instance.addDetail({ component: 'maybeBranch', at: root });
+        instance.addDetail({ component: 'maybeBranch', at: root });
     })
-    .define('leaf', (root: Point) => {
+    .define('leaf', (root: Point, _: GeneratorInstance) => {
         const leaf = root.attach(leafSphere);
         leaf.scale(Math.random() * 0.5 + 0.5);
     })
-    .maybe('maybeBranch', (root: Point) => {
-        treeGen.addDetail({ component: 'branch', at: root });
+    .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
+        instance.addDetail({ component: 'branch', at: root });
     });
-const tree = treeGen.generate({ start: 'branch', depth: 25 });
+const tree = treeGen.generateSOMC({ start: 'branch', depth: 150, costFn: (_: Node) => {
+    return 0;
+} });
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 3: set up renderer

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -106,7 +106,7 @@ treeGen
 const treeTarget = Model.create();
 const sphere = treeTarget.add(new GeometryNode(leafSphere));
 sphere.scale(4);
-sphere.moveTo({x: 5, y: 7, z: 0});
+sphere.moveTo({ x: 5, y: 7, z: 0 });
 
 const tree = treeGen.generateSOSMC({
     start: 'branch',

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -4,7 +4,6 @@ import {
     Light,
     Material,
     Matrix,
-    Model,
     Node,
     Point,
     Quaternion,
@@ -91,9 +90,13 @@ treeGen
     .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
         instance.addDetail({ component: 'branch', at: root });
     });
-const tree = treeGen.generateSOMC({ start: 'branch', depth: 150, costFn: (_: Node) => {
-    return 0;
-} });
+const tree = treeGen.generateSOMC({
+    start: 'branch',
+    depth: 150,
+    costFn: (_: Node) => {
+        return 0;
+    }
+});
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 3: set up renderer

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -2,9 +2,11 @@ import {
     Armature,
     CostFunction,
     GeneratorInstance,
+    GeometryNode,
     Light,
     Material,
     Matrix,
+    Model,
     Node,
     Point,
     Quaternion,
@@ -12,8 +14,6 @@ import {
     RGBColor,
     Shape
 } from '../calder';
-
-import { vec4 } from 'gl-matrix';
 
 // Create the renderer
 const renderer: Renderer = new Renderer({
@@ -94,7 +94,7 @@ treeGen
         instance.addDetail({ component: 'branch', at: root });
     });
 
-const tree = treeGen.generateSOMC({
+/*const tree = treeGen.generateSOMC({
     start: 'branch',
     depth: 150,
     samples: 100,
@@ -102,6 +102,18 @@ const tree = treeGen.generateSOMC({
         {point: {x: -50, y: 100, z: 0}, influence: -200},
         {point: {x: 0, y: -100, z: 0}, influence: 100}
     ])
+});*/
+
+const treeTarget = Model.create();
+const sphere = treeTarget.add(new GeometryNode(leafSphere));
+sphere.scale(4);
+sphere.moveTo({x: 5, y: 7, z: 0});
+
+const tree = treeGen.generateSOMC({
+    start: 'branch',
+    depth: 150,
+    samples: 100,
+    costFn: CostFunction.fillVolume(treeTarget, 0.2)
 });
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -105,14 +105,22 @@ treeGen
 
 const treeTarget = Model.create();
 const sphere = treeTarget.add(new GeometryNode(leafSphere));
-sphere.scale(4);
-sphere.moveTo({ x: 5, y: 7, z: 0 });
+sphere.scale(5);
+sphere.moveTo({ x: 0, y: 10, z: 0 });
 
 const tree = treeGen.generateSOSMC({
     start: 'branch',
-    depth: 150,
+    depth: 300,
     samples: 100,
-    costFn: CostFunction.fillVolume(treeTarget, 0.2)
+    costFn: CostFunction.fillVolume(treeTarget, 0.2),
+    onLastGeneration: (instances: GeneratorInstance[]) => {
+        const result = <HTMLParagraphElement>document.createElement('p');
+        result.innerText = instances
+            .map((instance: GeneratorInstance) => instance.getCost())
+            .sort((a: number, b: number) => a - b)
+            .join(', ');
+        document.body.appendChild(result);
+    }
 });
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -1,7 +1,7 @@
 import {
     Armature,
+    CostFunction,
     GeneratorInstance,
-    GeometryNode,
     Light,
     Material,
     Matrix,
@@ -94,23 +94,14 @@ treeGen
         instance.addDetail({ component: 'branch', at: root });
     });
 
-const target = vec4.fromValues(0, 100, 0, 1);
 const tree = treeGen.generateSOMC({
     start: 'branch',
     depth: 150,
     samples: 100,
-    costFn: (instance: GeneratorInstance, nodes: GeometryNode[]) => {
-        const distanceCost = nodes.reduce((sum: number, node: Node) => {
-            const localToGlobalTransform = node.localToGlobalTransform();
-            const globalPosition = vec4.transformMat4(vec4.create(), vec4.fromValues(0, 0, 0, 1), localToGlobalTransform);
-
-            return sum + vec4.length(vec4.sub(vec4.create(), target, globalPosition));
-        }, 0);
-        
-        const growthCost = 400 / instance.activeSpawnPoints();
-
-        return distanceCost * distanceCost + growthCost;
-    }
+    costFn: CostFunction.forces([
+        {point: {x: -50, y: 100, z: 0}, influence: -200},
+        {point: {x: 0, y: -100, z: 0}, influence: 100}
+    ])
 });
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -106,7 +106,6 @@ treeGen
 
 const treeTarget = Model.create();
 const sphere = treeTarget.add(new GeometryNode(leafSphere));
-//sphere.scale(4);
 sphere.moveTo({ x: 0, y: 3, z: 0 });
 const branch = treeTarget.add(new GeometryNode(branchShape));
 branch.scale({ x: 0.2, y: 2, z: 0.2 });

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -8,6 +8,7 @@ import {
     Light,
     Material,
     Matrix,
+    Model,
     Node,
     Quaternion,
     Renderer,
@@ -64,24 +65,24 @@ const bone = Armature.define((root: Node) => {
     root.createPoint('tip', { x: 0, y: 1, z: 0 });
 });
 
-const tower = bone();
+const tower = Model.create(bone());
 
-let top = tower;
+let top = tower.root();
 
 for (let i = 0; i < 5; i += 1) {
-    const nextPiece = bone();
+    const nextPiece = tower.add(bone());
     nextPiece.point('base').stickTo(top.point('tip'));
-    nextPiece.point('base').attach(sphere);
+    tower.add(nextPiece.point('base').attach(sphere));
     nextPiece.setRotation(Matrix.fromQuat4(Quaternion.fromEuler()));
     top = nextPiece;
 }
 
-const test = bone();
-test.setPosition({ x: 3, y: 0, z: 0 });
+const test = Model.create(bone());
+test.root().setPosition({ x: 3, y: 0, z: 0 });
 
-test.setScale(Matrix.fromScaling({ x: 1, y: 3, z: 1 }));
-const testChild = bone();
-testChild.point('base').stickTo(test.point('tip'));
+test.root().setScale(Matrix.fromScaling({ x: 1, y: 3, z: 1 }));
+const testChild = test.add(bone());
+testChild.point('base').stickTo(test.root().point('tip'));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 3: set up renderer
@@ -96,16 +97,16 @@ renderer.camera.lookAt({ x: 2, y: 2, z: -4 });
 
 // Create a new constraint to be applied to the `test` Node.
 const constraints = Constraints.getInstance();
-constraints.add(test, (node: Node) => {
+constraints.add(test.root(), (node: Node) => {
     node
         .hold(node.point('base'))
         .grab(node.point('tip'))
-        .stretchTo(tower.point('tip'))
+        .stretchTo(tower.root().point('tip'))
         .release();
 });
 
 Animation.create({
-    node: tower,
+    node: tower.root(),
     to: (node: Node) => {
         const theta = Math.random() * 90;
         const phi = Math.random() * 360;

--- a/src/geometry/BakedGeometry.ts
+++ b/src/geometry/BakedGeometry.ts
@@ -3,6 +3,16 @@ import REGL = require('regl');
 
 import { BakedMaterial } from '../calder';
 
+import { vec4 } from 'gl-matrix';
+
+/**
+ * An axis-aligned bounding box, defined by the minimum and maximum coordinates of the box.
+ */
+export type AABB = {
+    min: vec4;
+    max: vec4;
+};
+
 /**
  * After modelling is complete, a BakedGeometry should be returned for use in the renderer.
  */
@@ -15,4 +25,6 @@ export type BakedGeometry = {
     verticesBuffer?: REGL.Buffer;
     normalsBuffer?: REGL.Buffer;
     indicesBuffer?: REGL.Elements;
+
+    aabb: AABB;
 };

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -133,6 +133,18 @@ export class WorkingGeometry implements Bakeable {
         if (this.updateCache) {
             this.combine();
 
+            const min = vec4.fromValues(Infinity, Infinity, Infinity, 1);
+            const max = vec4.fromValues(-Infinity, -Infinity, -Infinity, 1);
+            this.vertices.forEach((vertex: vec4) => {
+                min[0] = Math.min(min[0], vertex[0]);
+                min[1] = Math.min(min[1], vertex[1]);
+                min[2] = Math.min(min[2], vertex[2]);
+
+                max[0] = Math.max(max[0], vertex[0]);
+                max[1] = Math.max(max[1], vertex[1]);
+                max[2] = Math.max(max[2], vertex[2]);
+            });
+
             const bakedVertices = flatMap(this.vertices, (workingVec: vec4) => [
                 workingVec[0],
                 workingVec[1],
@@ -151,7 +163,8 @@ export class WorkingGeometry implements Bakeable {
                 vertices: Float32Array.from(bakedVertices),
                 normals: Float32Array.from(bakedNormals),
                 indices: Int16Array.from(bakedIndices),
-                material: this.material.bake()
+                material: this.material.bake(),
+                aabb: {min, max}
             };
 
             this.updateCache = false;

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -164,7 +164,7 @@ export class WorkingGeometry implements Bakeable {
                 normals: Float32Array.from(bakedNormals),
                 indices: Int16Array.from(bakedIndices),
                 material: this.material.bake(),
-                aabb: {min, max}
+                aabb: { min, max }
             };
 
             this.updateCache = false;

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -13,6 +13,7 @@ import {
     DrawAxesProps,
     DrawObjectProps,
     Light,
+    Model,
     Node,
     RenderObject,
     RenderParams,
@@ -124,16 +125,14 @@ export class Renderer {
     }
 
     public draw(
-        objects: Node[],
+        objects: Model[],
         debug: DebugParams = { drawAxes: false, drawArmatureBones: false }
     ) {
         this.clearAll();
 
         const renderObjects = objects.reduce(
-            (accum: NodeRenderObject, node: Node) => {
-                const childObjects = node.traverse(
-                    mat4.create(),
-                    mat3.create(),
+            (accum: NodeRenderObject, model: Model) => {
+                const childObjects = model.traverse(
                     debug.drawArmatureBones === true
                 );
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -146,7 +146,7 @@ export class Renderer {
 
         const renderObjects = objects.reduce(
             (accum: NodeRenderObject, model: Model) => {
-                const childObjects = model.traverse(debug.drawArmatureBones === true);
+                const childObjects = model.computeRenderInfo(debug.drawArmatureBones === true);
 
                 [...childObjects.geometry, ...childObjects.bones].forEach((o: RenderObject) => {
                     if (o.geometry.verticesBuffer === undefined) {

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -1,4 +1,4 @@
-import { mat3, mat4, vec3, vec4 } from 'gl-matrix';
+import { mat4, vec3, vec4 } from 'gl-matrix';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
 import { NodeRenderObject } from '../armature/NodeRenderObject';
@@ -132,9 +132,7 @@ export class Renderer {
 
         const renderObjects = objects.reduce(
             (accum: NodeRenderObject, model: Model) => {
-                const childObjects = model.traverse(
-                    debug.drawArmatureBones === true
-                );
+                const childObjects = model.traverse(debug.drawArmatureBones === true);
 
                 [...childObjects.geometry, ...childObjects.bones].forEach((o: RenderObject) => {
                     if (o.geometry.verticesBuffer === undefined) {

--- a/src/types/RenderParams.ts
+++ b/src/types/RenderParams.ts
@@ -1,7 +1,8 @@
-import { DebugParams, Node } from '../calder';
+import { Model } from '../armature/Model';
+import { DebugParams } from '../calder';
 
 export type RenderParams = {
-    objects: Node[];
+    objects: Model[];
 
     debugParams?: DebugParams;
 };

--- a/tests/armature/Generator.spec.ts
+++ b/tests/armature/Generator.spec.ts
@@ -12,7 +12,7 @@ describe('Generator', () => {
         const towerGen = Armature.generator();
         const tower = towerGen
             .define('block', (root: Point, instance: GeneratorInstance) => {
-                const node = bone();
+                const node = instance.add(bone());
                 node.point('base').stickTo(root);
 
                 instance.addDetail({ component: 'block', at: node.point('tip') });
@@ -25,8 +25,8 @@ describe('Generator', () => {
     it('handles terminal nodes', () => {
         const towerGen = Armature.generator();
         const tower = towerGen
-            .define('block', (root: Point) => {
-                const node = bone();
+            .define('block', (root: Point, instance: GeneratorInstance) => {
+                const node = instance.add(bone());
                 node.point('base').stickTo(root);
 
                 // This definition does not add any more detail

--- a/tests/armature/Generator.spec.ts
+++ b/tests/armature/Generator.spec.ts
@@ -1,4 +1,5 @@
 import { Armature } from '../../src/armature/Armature';
+import { GeneratorInstance } from '../../src/armature/Generator';
 import { Node, Point } from '../../src/armature/Node';
 
 const bone = Armature.define((root: Node) => {
@@ -10,11 +11,11 @@ describe('Generator', () => {
     it('generates to the required depth', () => {
         const towerGen = Armature.generator();
         const tower = towerGen
-            .define('block', (root: Point) => {
+            .define('block', (root: Point, instance: GeneratorInstance) => {
                 const node = bone();
                 node.point('base').stickTo(root);
 
-                towerGen.addDetail({ component: 'block', at: node.point('tip') });
+                instance.addDetail({ component: 'block', at: node.point('tip') });
             })
             .generate({ start: 'block', depth: 5 });
 

--- a/tests/armature/Generator.spec.ts
+++ b/tests/armature/Generator.spec.ts
@@ -19,14 +19,7 @@ describe('Generator', () => {
             })
             .generate({ start: 'block', depth: 5 });
 
-        let depth = 0;
-        let block = tower;
-        while (block.children.length > 0) {
-            depth += 1;
-            block = block.children[0];
-        }
-
-        expect(depth).toBe(5);
+        expect(tower.nodes.length).toBe(6); // Root plus five blocks
     });
 
     it('handles terminal nodes', () => {
@@ -40,13 +33,6 @@ describe('Generator', () => {
             })
             .generate({ start: 'block', depth: 5 });
 
-        let depth = 0;
-        let block = tower;
-        while (block.children.length > 0) {
-            depth += 1;
-            block = block.children[0];
-        }
-
-        expect(depth).toBe(1);
+        expect(tower.nodes.length).toBe(2); // Root plus one block
     });
 });

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -516,7 +516,7 @@ describe('Node', () => {
         });
     });
 
-    describe('traverse', () => {
+    describe('computeRenderInfo', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
             const geometry: WorkingGeometry = new WorkingGeometry({
                 vertices: [vec3.create()],
@@ -549,7 +549,7 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(1, 0, 1, 1);
 
-            const renderObjects: RenderObject[] = model.traverse(false).geometry;
+            const renderObjects: RenderObject[] = model.computeRenderInfo(false).geometry;
 
             expect(renderObjects.length).toBe(1);
 
@@ -583,7 +583,7 @@ describe('Node', () => {
             const inputPoint = vec4.fromValues(0, 1, 0, 1);
             const expectedPoint = vec4.fromValues(0, 1, 0, 1);
 
-            const renderObjects: RenderObject[] = model.traverse(false).geometry;
+            const renderObjects: RenderObject[] = model.computeRenderInfo(false).geometry;
 
             expect(renderObjects.length).toBe(1);
 
@@ -609,7 +609,7 @@ describe('Node', () => {
             const expectedWorldSpaceBase = vec4.fromValues(0, 0, 0, 1);
             const expectedWorldSpaceTip = vec4.fromValues(0, 2, 0, 1);
 
-            const bones: RenderObject[] = Model.create(root).traverse(true).bones;
+            const bones: RenderObject[] = Model.create(root).computeRenderInfo(true).bones;
             expect(bones.length).toBe(2);
 
             // Check base and tip of bone 1

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -1,4 +1,4 @@
-import { mat3, mat4, quat, vec3, vec4 } from 'gl-matrix';
+import { mat4, quat, vec3, vec4 } from 'gl-matrix';
 import {
     defaultMaterial,
     Armature,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,14 +15,12 @@
     "noUnusedParameters": true,
     "noImplicitAny": false,
     "noImplicitThis": false,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "rootDir": ".",
+    "outDir": "build"
   },
   "include": [
     "src/**/*",
     "tests/**/*"
-  ],
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "build"
-  }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "lib": ["ES2016", "DOM"],
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,14 +863,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-es2015@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
@@ -5560,10 +5552,6 @@ rechoir@^0.6.2:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
-
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-es2015@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
@@ -5552,6 +5560,10 @@ rechoir@^0.6.2:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/125
Fixes https://github.com/calder-gl/calder/issues/126

At a high level, here is how SOSMC sampling works: you have `N` instances of a generator. Then, either until all instances have completed or you've done a set number of iterations:
1. Grow each generator instance once (let it add one new piece of geometry randomly)
2. Find the new cost of each each instance
3. `N` times, pick an instance randomly where lower cost instances have a higher chance of getting picked (and instances can get picked more than once.)
4. Replace your set of active instances with new copies of the ones you picked in step 3. We need new copies so that if you pick something more than once, the multiple versions of it can grow uniquely and independently from each other now.

So I implemented this in this PR. It didn't fit as well as I hoped into our existing system for the following reasons:
- When we didn't have multiple instances running, you could just reference your single instance when calling `addDetail` in your rule definitions. Now, because you don't know what instance you will be using when you declare rules, I have to pass in an instance to the rule declaration lambda so that you only find out which instance you are adding to at runtime.
- SOMC relies heavily on making copies of instances. Doing this in our system causes a lot of trouble:
  - We have to recursively walk the tree to do a deep copy. Even without running a real cost function, when I do a test SOMC run, it takes 8 seconds, all of which is spent doing deep copies and garbage collecting the last generation.
  - When we do a deep copy, we have to somehow replace the active spawn points, since they reference nodes on the original, uncopied instance. There's no easy way to say "make the same node point but on this deep copied version" because the spawn point could be anywhere in the hierarchy. I made a method that does a deep clone and simultaneously updates spawn points but it's gross: for every node in the hierarchy, for each spawn point, check if the spawn point is on that node. If so, when copying the node, replace that spawn point.

So here are my takeaways so far:
- SOMC is slow not only because of slow cost functions but also because it needs a deep copy to treat each sample independently. If we can do this more efficiently, that alone can be a win
- If we can do a non-SOMC algorithm that doesn't need a deep copy without the quality of the generated model suffering too much (e.g. the final cost isn't much higher), that's a win too

Things left to do:
- [x] Add more comments
- [x] Add cost function that doesn't just return 0 to make sure that it actually works