### PR TITLE
Removed need to call `bake` in the client calder code.

### DIFF
--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -1,6 +1,13 @@
 import { glMatrix, mat3, mat4, quat, vec3, vec4 } from 'gl-matrix';
 import { flatten, isNumber } from 'lodash';
-import { closestPointOnLine, coord, coordFunc, BakedGeometry, RenderObject } from '../calder';
+import {
+    closestPointOnLine,
+    coord,
+    coordFunc,
+    BakedGeometry,
+    RenderObject,
+    WorkingGeometry
+} from '../calder';
 import { vec3From4, vec3ToPoint } from '../math/utils';
 import { defaultMaterial } from '../renderer/Material';
 import { matrix4, vector3 } from '../types/InternalVectorTypes';
@@ -882,12 +889,12 @@ export class GeometryNode extends Node {
     /**
      * Instantiates a new `GeometryNode`.
      *
-     * @param {BakedGeometry} geometry
+     * @param {WorkingGeometry} geometry
      * @param {Node[]} children
      */
-    constructor(geometry: BakedGeometry, children: Node[] = []) {
+    constructor(geometry: WorkingGeometry, children: Node[] = []) {
         super(children);
-        this.geometry = geometry;
+        this.geometry = geometry.bake();
     }
 
     /**
@@ -953,10 +960,10 @@ export class Point {
     /**
      * Attaches the specified geometry to the current point on a node.
      *
-     * @param {BakedGeometry} geometry The geometry to attach to the current point.
+     * @param {WorkingGeometry} geometry The geometry to attach to the current point.
      * @returns {GeometryNode} The node created to hold the geometry.
      */
-    public attach(geometry: BakedGeometry): GeometryNode {
+    public attach(geometry: WorkingGeometry): GeometryNode {
         const geometryNode = new GeometryNode(geometry);
         geometryNode.setAnchor(vec3.fromValues(0, 0, 0));
         geometryNode.setPosition(Mapper.vectorToCoord(this.position));

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -36,13 +36,11 @@ renderer.addLight(light1);
 
 // Setup leaf
 const leafColor = RGBColor.fromRGB(204, 255, 204);
-const workingLeafSphere = Shape.sphere(Material.create({ color: leafColor, shininess: 100 }));
-const leafSphere = workingLeafSphere.bake();
+const leafSphere = Shape.sphere(Material.create({ color: leafColor, shininess: 100 }));
 
 // Setup branch
 const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
-const workingBranchShape = Shape.cylinder(Material.create({ color: branchColor, shininess: 1 }));
-const branchShape = workingBranchShape.bake();
+const branchShape = Shape.cylinder(Material.create({ color: branchColor, shininess: 1 }));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -2,7 +2,6 @@ import {
     identityMatrix4,
     Animation,
     Armature,
-    BakedGeometry,
     Constraints,
     CMYKColor,
     Light,
@@ -51,10 +50,7 @@ const red: CMYKColor = CMYKColor.fromCMYK(0, 1, 1, 0);
 const purple: CMYKColor = red.mix(blue);
 
 // Setup sphere
-const workingSphere: WorkingGeometry = Shape.sphere(
-    Material.create({ color: purple, shininess: 256 })
-);
-const sphere: BakedGeometry = workingSphere.bake();
+const sphere: WorkingGeometry = Shape.sphere(Material.create({ color: purple, shininess: 256 }));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 2: create armature

--- a/src/geometry/Shape.ts
+++ b/src/geometry/Shape.ts
@@ -23,7 +23,13 @@ export namespace Shape {
             (i: number) => new Face(range(i * 3, (i + 1) * 3))
         );
 
-        return new WorkingGeometry(vertices, vertices, faces, [], material);
+        return new WorkingGeometry({
+            vertices: vertices,
+            normals: vertices,
+            faces: faces,
+            controlPoints: [],
+            material: material
+        });
     }
 
     export function cylinder(material: Material = defaultMaterial): WorkingGeometry {
@@ -123,6 +129,12 @@ export namespace Shape {
             );
         });
 
-        return new WorkingGeometry(vertices, normals, faces, [], material);
+        return new WorkingGeometry({
+            vertices: vertices,
+            normals: normals,
+            faces: faces,
+            controlPoints: [],
+            material: material
+        });
     }
 }

--- a/src/geometry/Shape.ts
+++ b/src/geometry/Shape.ts
@@ -32,6 +32,7 @@ export namespace Shape {
         });
     }
 
+    // tslint:disable:max-func-body-length
     export function cylinder(material: Material = defaultMaterial): WorkingGeometry {
         const LENGTH = 1;
         const PRECISION = 20;

--- a/src/geometry/WorkingGeometry.ts
+++ b/src/geometry/WorkingGeometry.ts
@@ -22,6 +22,23 @@ export class Face {
     }
 }
 
+export type WorkingGeometryParams = {
+    // The points that make up the geometry.
+    vertices: vec3[];
+
+    // The normals corresponding to the vertices.
+    normals: vec3[];
+
+    // The surfaces of the object, relating the vertices to each other.
+    faces: Face[];
+
+    // A set of points to snap to or reference.
+    controlPoints: vec3[];
+
+    // The material for this WorkingGeometry.
+    material: Material;
+};
+
 /**
  * A representation of geometry while modelling is happening.
  */
@@ -66,27 +83,25 @@ export class WorkingGeometry implements Bakeable {
     /**
      * Creates a working geometry from a given set of vertices, faces, and control points.
      *
-     * @param {vec3[]} vertices: The points that make up the geometry.
-     * @param {vec3[]} normals: The normals corresponding to the vertices.
-     * @param {Face[]} faces: The surfaces of the object, relating the vertices to each other.
-     * @param {vec3[]} controlPoints: A set of points to snap to or reference.
-     * @param {Material} material: The material for this WorkingGeometry.
+     * @param {WorkingGeometryParams} params: Parameters for creating a `WorkingGeometry`.
      * @return {WorkingGeometry}
      */
     constructor(
-        vertices: vec3[] = [],
-        normals: vec3[] = [],
-        faces: Face[] = [],
-        controlPoints: vec3[] = [],
-        material: Material = defaultMaterial
+        params: WorkingGeometryParams = {
+            vertices: [],
+            normals: [],
+            faces: [],
+            controlPoints: [],
+            material: defaultMaterial
+        }
     ) {
         // TODO(pbardea): Check if max(indices) of all faces is <= the len(vertices)
-        this.vertices = vertices.map(Affine.createPoint);
-        this.normals = normals.map(Affine.createVector);
-        this.faces = faces;
-        this.controlPoints = controlPoints.map(Affine.createPoint);
+        this.vertices = params.vertices.map(Affine.createPoint);
+        this.normals = params.normals.map(Affine.createVector);
+        this.faces = params.faces;
+        this.controlPoints = params.controlPoints.map(Affine.createPoint);
         this.mergedObjects = [];
-        this.material = material;
+        this.material = params.material;
     }
 
     /**

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -2,10 +2,11 @@ import { mat3, mat4, quat, vec3, vec4 } from 'gl-matrix';
 import {
     defaultMaterial,
     Armature,
-    BakedGeometry,
+    Face,
     GeometryNode,
     Node,
-    RenderObject
+    RenderObject,
+    WorkingGeometry
 } from '../../src/calder';
 import '../glMatrix';
 
@@ -149,12 +150,13 @@ describe('Node', () => {
     describe('attach', () => {
         it('creates a GeometryNode for the attached geometry', () => {
             const parent = bone();
-            const geometry: BakedGeometry = {
-                vertices: Float32Array.from([]),
-                normals: Float32Array.from([]),
-                indices: Int16Array.from([]),
+            const geometry: WorkingGeometry = new WorkingGeometry({
+                vertices: [vec3.create()],
+                normals: [vec3.create()],
+                faces: [new Face([])],
+                controlPoints: [vec3.create()],
                 material: defaultMaterial
-            };
+            });
 
             parent.point('tip').attach(geometry);
             expect(parent.children.length).toBe(1);
@@ -515,12 +517,13 @@ describe('Node', () => {
 
     describe('traverse', () => {
         it("flattens the parent's coordinate space and returns an array of `RenderObject`s", () => {
-            const geometry: BakedGeometry = {
-                vertices: Float32Array.from([]),
-                normals: Float32Array.from([]),
-                indices: Int16Array.from([]),
+            const geometry: WorkingGeometry = new WorkingGeometry({
+                vertices: [vec3.create()],
+                normals: [vec3.create()],
+                faces: [new Face([])],
+                controlPoints: [vec3.create()],
                 material: defaultMaterial
-            };
+            });
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);
@@ -555,12 +558,13 @@ describe('Node', () => {
         });
 
         it('defaults to no transformation', () => {
-            const geometry: BakedGeometry = {
-                vertices: Float32Array.from([]),
-                normals: Float32Array.from([]),
-                indices: Int16Array.from([]),
+            const geometry: WorkingGeometry = new WorkingGeometry({
+                vertices: [vec3.create()],
+                normals: [vec3.create()],
+                faces: [new Face([])],
+                controlPoints: [vec3.create()],
                 material: defaultMaterial
-            };
+            });
             const geometryChild = new GeometryNode(geometry);
             const nodeChild = new Node([geometryChild]);
             const root = new Node([nodeChild]);

--- a/tests/geometry/WorkingGeometry.spec.ts
+++ b/tests/geometry/WorkingGeometry.spec.ts
@@ -4,6 +4,7 @@ import { TestHelper } from '../utils/helper';
 import { vec3, vec4 } from 'gl-matrix';
 import { flatten, flatMap } from 'lodash';
 
+import { defaultMaterial } from '../../src/calder';
 import '../glMatrix';
 
 function compareFloatArrays(actual: Float32Array, expected: Float32Array) {
@@ -49,7 +50,13 @@ describe('WorkingGeometry', () => {
             ];
             const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
-            const geo = new WorkingGeometry(vertices, normals, faces, controlPoints);
+            const geo = new WorkingGeometry({
+                vertices: vertices,
+                normals: normals,
+                faces: faces,
+                controlPoints: controlPoints,
+                material: defaultMaterial
+            });
 
             expect(geo.vertices).toEqual([
                 vec4.fromValues(0, 0, 0, 1),
@@ -77,7 +84,13 @@ describe('WorkingGeometry', () => {
             ];
             const faces = [new Face([0, 1, 2]), new Face([0, 2, 3])];
             const controlPoints = [vec3.fromValues(0, 0, 0)];
-            const square = new WorkingGeometry(vertices, normals, faces, controlPoints);
+            const square = new WorkingGeometry({
+                vertices: vertices,
+                normals: normals,
+                faces: faces,
+                controlPoints: controlPoints,
+                material: defaultMaterial
+            });
             const bakedSquare = square.bake();
 
             // Not testing the colors yet since they don't do anything useful
@@ -91,6 +104,7 @@ describe('WorkingGeometry', () => {
                 Float32Array.from(flatMap(normals, (n: vec3) => [n[0], n[1], n[2]]))
             );
         });
+
         it('can bake a WorkingGeometry that has many merged objects', () => {
             const rootSquare = TestHelper.square();
             const childSquare1 = TestHelper.square(vec3.fromValues(1, 0, 0));

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -2,6 +2,7 @@ import { vec3 } from 'gl-matrix';
 import { Face, WorkingGeometry } from '../../src/geometry/WorkingGeometry';
 
 import { flatMap } from 'lodash';
+import { defaultMaterial } from '../../src/calder';
 
 export namespace TestHelper {
     /**
@@ -17,10 +18,10 @@ export namespace TestHelper {
         size: number = 1
     ): WorkingGeometry {
         /*
-         *   1----2     y    
-         *   |    |     | z     
-         *   |    |     |/     
-         *   0----3     +--x     
+         *   1----2     y
+         *   |    |     | z
+         *   |    |     |/
+         *   0----3     +--x
          */
         const unitVertices = [
             vec3.fromValues(0, 0, 0),
@@ -44,7 +45,13 @@ export namespace TestHelper {
             return out;
         });
 
-        return new WorkingGeometry(vertices, normals, faces, controlPoints);
+        return new WorkingGeometry({
+            vertices: vertices,
+            normals: normals,
+            faces: faces,
+            controlPoints: controlPoints,
+            material: defaultMaterial
+        });
     }
 
     /**
@@ -62,14 +69,14 @@ export namespace TestHelper {
         // TODO(pbardea): This is currently just used by tests, but this should be exposed as
         // basic geometrical structures for the user.
         /*
-		 *      5-------6
-		 *     /|      /|
-		 *    1-+-----2 | 
-		 *    | |     | |   y
-		 *    | 4-----+-7   | z
-		 *    |/      |/    |/
-		 *    0-------3     +--x
-		 */
+     *      5-------6
+     *     /|      /|
+     *    1-+-----2 |
+     *    | |     | |   y
+     *    | 4-----+-7   | z
+     *    |/      |/    |/
+     *    0-------3     +--x
+     */
         const cubeVertices = [
             // Front side of cube.
             vec3.fromValues(0, 0, 0),
@@ -144,6 +151,12 @@ export namespace TestHelper {
             return out;
         });
 
-        return new WorkingGeometry(vertices, normals, faces, controlPoints);
+        return new WorkingGeometry({
+            vertices: vertices,
+            normals: normals,
+            faces: faces,
+            controlPoints: controlPoints,
+            material: defaultMaterial
+        });
     }
 }

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -17,7 +17,7 @@ export namespace TestHelper {
         start: vec3 = vec3.fromValues(0, 0, 0),
         size: number = 1
     ): WorkingGeometry {
-        /*
+        /**
          *   1----2     y
          *   |    |     | z
          *   |    |     |/
@@ -68,15 +68,15 @@ export namespace TestHelper {
     ): WorkingGeometry {
         // TODO(pbardea): This is currently just used by tests, but this should be exposed as
         // basic geometrical structures for the user.
-        /*
-     *      5-------6
-     *     /|      /|
-     *    1-+-----2 |
-     *    | |     | |   y
-     *    | 4-----+-7   | z
-     *    |/      |/    |/
-     *    0-------3     +--x
-     */
+        /**
+         *      5-------6
+         *     /|      /|
+         *    1-+-----2 |
+         *    | |     | |   y
+         *    | 4-----+-7   | z
+         *    |/      |/    |/
+         *    0-------3     +--x
+         */
         const cubeVertices = [
             // Front side of cube.
             vec3.fromValues(0, 0, 0),


### PR DESCRIPTION
Closes #123.

- [x] Add ruby like memoization for `BakedGeometry` `bake()` method which is invalidated upon mutating the said `BakedGeometry` instance.