### PR TITLE
Add heuristic cost

### DIFF
--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -130,7 +130,7 @@ export namespace CostFunction {
                     onAdded(point);
                 }
             });
-        }
+        };
 
         // For each node in the target model, find its bounding box
         const targetCoords: Grid = {};
@@ -162,18 +162,29 @@ export namespace CostFunction {
             // that wasn't previously filled, and make the current model cost less accordingly
             added.forEach((n: Node) =>
                 n.geometryCallback((node: GeometryNode) =>
-                    addAABBToGrid(worldSpaceAABB(node, node.geometry.aabb), grid, (point: string) => 
-                        // If this point was in the target region, reduce the cost
-                        incrementalCost +=
-                        cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1))));
+                    addAABBToGrid(
+                        worldSpaceAABB(node, node.geometry.aabb),
+                        grid,
+                        (point: string) =>
+                            // If this point was in the target region, reduce the cost
+                            (incrementalCost +=
+                                cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1))
+                    )
+                )
+            );
 
             gridCache.set(instance.getModel().latest(), grid);
 
-            const heuristicGrid = {...grid};
+            const heuristicGrid = { ...grid };
             instance.getSpawnPoints().forEach((spawnPoint: SpawnPoint) => {
                 const aabb = instance.generator.getExpectedRuleVolume(spawnPoint.component);
-                addAABBToGrid(worldSpaceAABB(spawnPoint.at.node, aabb), heuristicGrid, (point: string) =>
-                    heuristicCost += cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1));
+                addAABBToGrid(
+                    worldSpaceAABB(spawnPoint.at.node, aabb),
+                    heuristicGrid,
+                    (point: string) =>
+                        (heuristicCost +=
+                            cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1))
+                );
             });
 
             return { realCost: instance.getCost().realCost + incrementalCost, heuristicCost };

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -1,8 +1,9 @@
 import { coord } from '../calder';
 import { AABB } from '../geometry/BakedGeometry';
 import { vec3From4 } from '../math/utils';
+import { worldSpaceAABB } from '../utils/aabb';
 import { Mapper } from '../utils/mapper';
-import { CostFn, GeneratorInstance } from './Generator';
+import { CostFn, GeneratorInstance, SpawnPoint } from './Generator';
 import { Model } from './Model';
 import { GeometryNode, Node } from './Node';
 
@@ -68,24 +69,6 @@ export namespace CostFunction {
         };
     }
 
-    // Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
-    // and a max corner.
-    const worldSpaceAABB = (node: GeometryNode) => {
-        const localToGlobalTransform = node.localToGlobalTransform();
-        const min = vec4.transformMat4(
-            vec4.create(),
-            node.geometry.aabb.min,
-            localToGlobalTransform
-        );
-        const max = vec4.transformMat4(
-            vec4.create(),
-            node.geometry.aabb.max,
-            localToGlobalTransform
-        );
-
-        return { min, max };
-    };
-
     /**
      * Creates a cost function based on how much of a target volume a shape fills.
      *
@@ -93,6 +76,7 @@ export namespace CostFunction {
      * @param {number} cellSize How big each cell in the volume grid should be.
      * @returns {CostFn} The resulting cost function.
      */
+    // tslint:disable-next-line:max-func-body-length
     export function fillVolume(targetModel: Model, cellSize: number): CostFn {
         const gridCache = new Map<Node, Grid>();
 
@@ -110,6 +94,9 @@ export namespace CostFunction {
         const pointsInAABB = (aabb: AABB) => {
             const points: string[] = [];
             const point = vec4.fromValues(0, 0, 0, 1);
+            if (isNaN(vec4.squaredLength(aabb.min)) || isNaN(vec4.squaredLength(aabb.max))) {
+                return [];
+            }
 
             // Step through x, y, and z from min to max, adding each step to the
             // `points` array
@@ -135,11 +122,21 @@ export namespace CostFunction {
             return points;
         };
 
+        const addAABBToGrid = (aabb: AABB, grid: Grid, onAdded: (added: string) => void) => {
+            pointsInAABB(aabb).forEach((point: string) => {
+                if (!grid[point]) {
+                    grid[point] = true;
+
+                    onAdded(point);
+                }
+            });
+        }
+
         // For each node in the target model, find its bounding box
         const targetCoords: Grid = {};
         targetModel.nodes.forEach((n: Node) =>
             n.geometryCallback((node: GeometryNode) => {
-                pointsInAABB(worldSpaceAABB(node)).forEach(
+                pointsInAABB(worldSpaceAABB(node, node.geometry.aabb)).forEach(
                     (point: string) => (targetCoords[point] = true)
                 );
             })
@@ -159,26 +156,27 @@ export namespace CostFunction {
             const grid = parentGrid === undefined ? {} : { ...parentGrid };
 
             let incrementalCost = 0;
+            let heuristicCost = 0;
 
             // For each point in the new added geometry, see if it fills a point in the target shape
             // that wasn't previously filled, and make the current model cost less accordingly
             added.forEach((n: Node) =>
-                n.geometryCallback((node: GeometryNode) => {
-                    pointsInAABB(worldSpaceAABB(node)).forEach((point: string) => {
-                        if (!grid[point]) {
-                            grid[point] = true;
-
-                            // If this point was in the target region, reduce the cost
-                            incrementalCost +=
-                                cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1);
-                        }
-                    });
-                })
-            );
+                n.geometryCallback((node: GeometryNode) =>
+                    addAABBToGrid(worldSpaceAABB(node, node.geometry.aabb), grid, (point: string) => 
+                        // If this point was in the target region, reduce the cost
+                        incrementalCost +=
+                        cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1))));
 
             gridCache.set(instance.getModel().latest(), grid);
 
-            return { realCost: instance.getCost().realCost + incrementalCost, heuristicCost: 0 };
+            const heuristicGrid = {...grid};
+            instance.getSpawnPoints().forEach((spawnPoint: SpawnPoint) => {
+                const aabb = instance.generator.getExpectedRuleVolume(spawnPoint.component);
+                addAABBToGrid(worldSpaceAABB(spawnPoint.at.node, aabb), heuristicGrid, (point: string) =>
+                    heuristicCost += cellSize * cellSize * cellSize * (targetCoords[point] ? -1 : 1));
+            });
+
+            return { realCost: instance.getCost().realCost + incrementalCost, heuristicCost };
         };
     }
 }

--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -97,6 +97,9 @@ export class GeneratorInstance {
         return this.model;
     }
 
+    /**
+     * @returns {SpawnPoint[]} The currently open spawn points that have yet to be generated from.
+     */
     public getSpawnPoints(): SpawnPoint[] {
         return this.spawnPoints;
     }
@@ -126,10 +129,6 @@ export class GeneratorInstance {
      */
     public addDetail(spawnPoint: SpawnPoint) {
         this.spawnPoints.push(spawnPoint);
-    }
-
-    public openSpawnPoints(): SpawnPoint[] {
-        return this.spawnPoints;
     }
 
     /**
@@ -392,18 +391,32 @@ export class Generator {
         throw new Error('Error finding a weighted definition. Are all weights positive?');
     }
 
+    /**
+     * Picks a plausible bounding volume that a component, when generated, could occupy.
+     *
+     * @param {string} component The component being spawned.
+     * @returns {AABB} An axis-aligned bounding box that the component could occupy.
+     */
     public getExpectedRuleVolume(component: string): AABB {
         const volumes = this.rules[component].expectedVolumes;
 
-        return volumes[ Math.floor(Math.random() * volumes.length) ];
+        return volumes[Math.floor(Math.random() * volumes.length)];
     }
 
+    /**
+     * Generates each component multiple times to compute expected bounding volumes.
+     *
+     * @param {number} numVolumes The number of bounding volumes to generate per component.
+     * @param {number} depth How many rounds of generation should be used per generated instance
+     * of a component.
+     */
     private computeExpectedVolumes(numVolumes: number, depth: number) {
         Object.keys(this.rules).forEach((name: string) => {
             const rule = this.rules[name];
 
-            rule.expectedVolumes = range(numVolumes).map(() => 
-                this.generate({start: name, depth}).computeAABB());
+            rule.expectedVolumes = range(numVolumes).map(() =>
+                this.generate({ start: name, depth }).computeAABB()
+            );
         });
     }
 }

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -146,21 +146,26 @@ export class Model {
         return result;
     }
 
+    /**
+     * @returns {AABB} A model-space axis-aligned bounding box that contains the whole model.
+     */
     public computeAABB(): AABB {
         const min = vec4.fromValues(Infinity, Infinity, Infinity, 1);
         const max = vec4.fromValues(-Infinity, -Infinity, -Infinity, 1);
 
-        this.nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
-            const aabb = worldSpaceAABB(node, node.geometry.aabb);
+        this.nodes.forEach((n: Node) =>
+            n.geometryCallback((node: GeometryNode) => {
+                const aabb = worldSpaceAABB(node, node.geometry.aabb);
 
-            min[0] = Math.min(Math.min(min[0], aabb.min[0]), aabb.max[0]);
-            min[1] = Math.min(Math.min(min[1], aabb.min[1]), aabb.max[1]);
-            min[2] = Math.min(Math.min(min[2], aabb.min[2]), aabb.max[2]);
+                min[0] = Math.min(Math.min(min[0], aabb.min[0]), aabb.max[0]);
+                min[1] = Math.min(Math.min(min[1], aabb.min[1]), aabb.max[1]);
+                min[2] = Math.min(Math.min(min[2], aabb.min[2]), aabb.max[2]);
 
-            max[0] = Math.max(Math.max(max[0], aabb.min[0]), aabb.max[0]);
-            max[1] = Math.max(Math.max(max[1], aabb.min[1]), aabb.max[1]);
-            max[2] = Math.max(Math.max(max[2], aabb.min[2]), aabb.max[2]);
-        }));
+                max[0] = Math.max(Math.max(max[0], aabb.min[0]), aabb.max[0]);
+                max[1] = Math.max(Math.max(max[1], aabb.min[1]), aabb.max[1]);
+                max[2] = Math.max(Math.max(max[2], aabb.min[2]), aabb.max[2]);
+            })
+        );
 
         return { min, max };
     }

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -1,6 +1,8 @@
-import { mat3, mat4 } from 'gl-matrix';
+import { mat3, mat4, vec4 } from 'gl-matrix';
 
-import { Node } from './Node';
+import { AABB } from '../geometry/BakedGeometry';
+import { worldSpaceAABB } from '../utils/aabb';
+import { GeometryNode, Node } from './Node';
 import { NodeRenderObject } from './NodeRenderObject';
 
 type RenderInfo = {
@@ -142,5 +144,24 @@ export class Model {
         }
 
         return result;
+    }
+
+    public computeAABB(): AABB {
+        const min = vec4.fromValues(Infinity, Infinity, Infinity, 1);
+        const max = vec4.fromValues(-Infinity, -Infinity, -Infinity, 1);
+
+        this.nodes.forEach((n: Node) => n.geometryCallback((node: GeometryNode) => {
+            const aabb = worldSpaceAABB(node, node.geometry.aabb);
+
+            min[0] = Math.min(Math.min(min[0], aabb.min[0]), aabb.max[0]);
+            min[1] = Math.min(Math.min(min[1], aabb.min[1]), aabb.max[1]);
+            min[2] = Math.min(Math.min(min[2], aabb.min[2]), aabb.max[2]);
+
+            max[0] = Math.max(Math.max(max[0], aabb.min[0]), aabb.max[0]);
+            max[1] = Math.max(Math.max(max[1], aabb.min[1]), aabb.max[1]);
+            max[2] = Math.max(Math.max(max[2], aabb.min[2]), aabb.max[2]);
+        }));
+
+        return { min, max };
     }
 }

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -115,7 +115,7 @@ const tree = treeGen.generateSOSMC({
     start: 'branch',
     depth: 200,
     samples: 100,
-    costFn: CostFunction.fillVolume(treeTarget, 0.2),
+    costFn: CostFunction.fillVolume(treeTarget, 0.4),
     onLastGeneration: (instances: GeneratorInstance[]) => {
         const result = document.createElement('p');
         result.innerText = 'Costs in final generation: ';

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -114,7 +114,7 @@ branch.moveTo({ x: 0, y: 1, z: 0 });
 const tree = treeGen.generateSOSMC({
     start: 'branch',
     depth: 200,
-    samples: 100,
+    samples: 50,
     costFn: CostFunction.fillVolume(treeTarget, 0.4),
     onLastGeneration: (instances: GeneratorInstance[]) => {
         const result = document.createElement('p');

--- a/src/utils/aabb.ts
+++ b/src/utils/aabb.ts
@@ -4,28 +4,37 @@ import { AABB } from '../geometry/BakedGeometry';
 import { mat4, vec4 } from 'gl-matrix';
 
 /**
- * Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
- * and a max corner.
+ * Given a node and a bounding box in the node's coordinate space, return the bounding box in
+ * world space.
+ *
+ * @param {Node} node The node the bounding box is for.
+ * @param {AABB} aabb The bounding box to be transformed.
+ * @returns {AABB} The bounding box in world space.
  */
 export function worldSpaceAABB(node: Node, aabb: AABB): AABB {
     const localToGlobalTransform = node.localToGlobalTransform();
-    const min = vec4.transformMat4(
-        vec4.create(),
-        aabb.min,
-        localToGlobalTransform
-    );
-    const max = vec4.transformMat4(
-        vec4.create(),
-        aabb.max,
-        localToGlobalTransform
-    );
+    const min = vec4.transformMat4(vec4.create(), aabb.min, localToGlobalTransform);
+    const max = vec4.transformMat4(vec4.create(), aabb.max, localToGlobalTransform);
 
     return { min, max };
-};
+}
 
+/**
+ * Given a point and a bounding box, aligns the bounding box to the point and returns the
+ * resulting world-space bounding box. This is useful when you know the bounding box for a
+ * component and know where the component will spawn and want to find out what the bounding box
+ * for the spawned component will be in world-space.
+ *
+ * @param {AABB} aabb The model-space AABB.
+ * @param {Point} point The point to align the AABB to.
+ */
 export function aabbAtPoint(aabb: AABB, point: Point): AABB {
     const localToGlobalTransform = point.node.localToGlobalTransform();
-    mat4.multiply(localToGlobalTransform, localToGlobalTransform, mat4.translate(mat4.create(), mat4.create(), point.position));
+    mat4.multiply(
+        localToGlobalTransform,
+        localToGlobalTransform,
+        mat4.translate(mat4.create(), mat4.create(), point.position)
+    );
 
     const min = vec4.transformMat4(vec4.create(), aabb.min, localToGlobalTransform);
     const max = vec4.transformMat4(vec4.create(), aabb.max, localToGlobalTransform);

--- a/src/utils/aabb.ts
+++ b/src/utils/aabb.ts
@@ -1,0 +1,34 @@
+import { Node, Point } from '../armature/Node';
+import { AABB } from '../geometry/BakedGeometry';
+
+import { mat4, vec4 } from 'gl-matrix';
+
+/**
+ * Given a GeometryNode, make an axis-aligned bounding box, which consists of a min corner
+ * and a max corner.
+ */
+export function worldSpaceAABB(node: Node, aabb: AABB): AABB {
+    const localToGlobalTransform = node.localToGlobalTransform();
+    const min = vec4.transformMat4(
+        vec4.create(),
+        aabb.min,
+        localToGlobalTransform
+    );
+    const max = vec4.transformMat4(
+        vec4.create(),
+        aabb.max,
+        localToGlobalTransform
+    );
+
+    return { min, max };
+};
+
+export function aabbAtPoint(aabb: AABB, point: Point): AABB {
+    const localToGlobalTransform = point.node.localToGlobalTransform();
+    mat4.multiply(localToGlobalTransform, localToGlobalTransform, mat4.translate(mat4.create(), mat4.create(), point.position));
+
+    const min = vec4.transformMat4(vec4.create(), aabb.min, localToGlobalTransform);
+    const max = vec4.transformMat4(vec4.create(), aabb.max, localToGlobalTransform);
+
+    return { min, max };
+}


### PR DESCRIPTION
Here's what this does:
- before running SOSMC, generate a few instances of each component
- save the bounding box for those generated components
- When doing the cost in SOSMC, for each open spawn point, pick a random bounding box from the generated bounding boxes for the spawn point's component and use that as a guess for the future shape

Issues
- Some `maybe` components can end up with no bounding boxes. Averaging of some kind will probably help

In general, this seems better than before, but still with lots of room for improvement.

![screen shot 2018-07-16 at 12 06 05 pm](https://user-images.githubusercontent.com/5315059/42769735-15b0a134-88f1-11e8-893d-c5460df989e0.png)
