### PR TITLE
Add distance multiplier

### DIFF
--- a/examples/forest.html
+++ b/examples/forest.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Generation example</title>
+  </head>
+  <body>
+    <script type="text/javascript" src="../public/build/forest.js"></script>
+  </body>
+</html>

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -1,9 +1,7 @@
 import { FillVolume } from './FillVolume';
 import { Forces, ForcePoint } from './Forces';
-import { GuidingVectors } from './GuidingVectors';
+import { Curve, GuidingVectors } from './GuidingVectors';
 import { Model } from './Model';
-
-import 'bezier-js';
 
 export namespace CostFunction {
     export function forces(forcePoints: ForcePoint[]): Forces {
@@ -14,7 +12,7 @@ export namespace CostFunction {
         return new FillVolume(targetModel, cellSize);
     }
 
-    export function guidingVectors(curves: BezierJs.Bezier[]): GuidingVectors {
+    export function guidingVectors(curves: Curve[]): GuidingVectors {
         return new GuidingVectors(curves);
     }
 }

--- a/src/armature/CostFunction.ts
+++ b/src/armature/CostFunction.ts
@@ -1,6 +1,6 @@
 import { FillVolume } from './FillVolume';
 import { Forces, ForcePoint } from './Forces';
-import { Curve, GuidingVectors } from './GuidingVectors';
+import { GuidingCurve, GuidingVectors } from './GuidingVectors';
 import { Model } from './Model';
 
 export namespace CostFunction {
@@ -12,7 +12,7 @@ export namespace CostFunction {
         return new FillVolume(targetModel, cellSize);
     }
 
-    export function guidingVectors(curves: Curve[]): GuidingVectors {
+    export function guidingVectors(curves: GuidingCurve[]): GuidingVectors {
         return new GuidingVectors(curves);
     }
 }

--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -22,7 +22,8 @@ export type DistanceMultiplier = [number, number, number];
 
 export type Curve = {
     bezier: BezierJs.Bezier;
-    multiplier: DistanceMultiplier;
+    distanceMultiplier: DistanceMultiplier;
+    alignmentMultiplier: number;
 };
 
 /**
@@ -150,7 +151,9 @@ export class GuidingVectors implements CostFn {
             const guidingVector = Mapper.coordToVector(<coord>closest.curve.bezier.derivative(
                 <number>closest.point.t
             ));
-            const alignmentCost = (-vec3.dot(guidingVector, vec3From4(vector)) + 1) * 100;
+            const alignmentCost =
+                (-vec3.dot(guidingVector, vec3From4(vector)) + 1) *
+                closest.curve.alignmentMultiplier;
 
             // Add cost for the distance away from the curve
             const closestPoint = vec3ToVector(Mapper.coordToVector(<coord>closest.point));
@@ -159,7 +162,7 @@ export class GuidingVectors implements CostFn {
             // Evaluate distance cost polynomial using Horner's method
             let distanceCost = 0;
             for (let power = 2; power >= 0; power -= 1) {
-                distanceCost = closest.curve.multiplier[power] + distanceCost * distance;
+                distanceCost = closest.curve.distanceMultiplier[power] + distanceCost * distance;
             }
 
             totalCost += alignmentCost + distanceCost;

--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -56,7 +56,7 @@ export type GuidingCurve = {
      * A positive offset therefore means structure needs to be **more aligned** in order to be
      * incentivized (the higher the offset, the closer it has to be to perfect alignment).
      *
-     * A negative negative offset means that alignment is more leniant and is incentivized even if
+     * A negative negative offset means that alignment is more lenient and is incentivized even if
      * structure is facing away from the vector field. This can be useful if adding *any* new
      * structure should be incentivized over only adding well-aligned structure.
      */

--- a/src/calder.ts
+++ b/src/calder.ts
@@ -33,6 +33,7 @@ export * from './armature/Armature';
 export * from './armature/Constraints';
 export * from './armature/CostFunction';
 export * from './armature/Generator';
+export * from './armature/GuidingVectors';
 export * from './armature/Model';
 export * from './armature/Node';
 

--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -62,7 +62,7 @@ const bone = Armature.define((root: Node) => {
 const treeGen = Armature.generator();
 treeGen
     .define('forest', (_: Point, instance: GeneratorInstance) => {
-        range(5).forEach(() => {
+        range(15).forEach(() => {
             const node = instance.add(bone());
             node
                 // Move to random spot in [-8, 8] x [-8, 8] on the ground
@@ -109,23 +109,25 @@ treeGen
 const guidingVectors = CostFunction.guidingVectors([
     {
         bezier: new Bezier([
-            { x: 0, y: 0, z: 0 },
-            { x: 2, y: 0.5, z: 0 },
-            { x: 6, y: 1.5, z: 0 },
-            { x: 8, y: 2, z: 0 }
+            { x: 2, y: -1, z: 0 },
+            { x: 2.5, y: 0, z: 0 },
+            { x: 5, y: 2.9, z: 0 },
+            { x: 6, y: 3, z: 0 }
         ]),
         distanceMultiplier: GuidingVectors.NONE,
-        alignmentMultiplier: 1000
+        alignmentMultiplier: 100,
+        alignmentOffset: 0.85
     }
 ]);
 
 const guidingCurve = guidingVectors.generateGuidingCurve();
+const vectorField = guidingVectors.generateVectorField(8, 2);
 
 const tree = treeGen.generateSOSMC({
     start: 'forest',
-    sosmcDepth: 100,
-    finalDepth: 100,
-    samples: 400,
+    sosmcDepth: 200,
+    finalDepth: 200,
+    samples: 500,
     costFn: guidingVectors,
     onLastGeneration: (instances: GeneratorInstance[]) => {
         const result = document.createElement('p');
@@ -162,7 +164,8 @@ const draw = () => {
         debugParams: {
             drawAxes: true,
             drawArmatureBones: false,
-            drawGuidingCurve: guidingCurve
+            drawGuidingCurve: guidingCurve,
+            drawVectorField: vectorField
         }
     };
 };

--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -128,17 +128,7 @@ const tree = treeGen.generateSOSMC({
     sosmcDepth: 200,
     finalDepth: 200,
     samples: 500,
-    costFn: guidingVectors,
-    onLastGeneration: (instances: GeneratorInstance[]) => {
-        const result = document.createElement('p');
-        result.innerText = 'Costs in final generation: ';
-        result.innerText += instances
-            .map((instance: GeneratorInstance) => instance.getCost().realCost)
-            .sort((a: number, b: number) => a - b)
-            .map((cost: number) => Math.round(cost * 100) / 100)
-            .join(', ');
-        document.body.appendChild(result);
-    }
+    costFn: guidingVectors
 });
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -103,7 +103,8 @@ const guidingVectors = CostFunction.guidingVectors([
             { x: 2, y: 2, z: 1 }
         ]),
         distanceMultiplier: GuidingVectors.QUADRATIC,
-        alignmentMultiplier: 500
+        alignmentMultiplier: 500,
+        alignmentOffset: 0.7
     },
     {
         bezier: new Bezier([
@@ -113,7 +114,8 @@ const guidingVectors = CostFunction.guidingVectors([
             { x: 0, y: 3, z: 2 }
         ]),
         distanceMultiplier: GuidingVectors.QUADRATIC,
-        alignmentMultiplier: 500
+        alignmentMultiplier: 500,
+        alignmentOffset: 0.6
     }
 ]);
 

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -2,6 +2,7 @@ import {
     Armature,
     CostFunction,
     GeneratorInstance,
+    GuidingVectors,
     Light,
     Material,
     Node,
@@ -94,18 +95,24 @@ treeGen
     });
 
 const guidingVectors = CostFunction.guidingVectors([
-    new Bezier([
-        { x: 0, y: 0, z: 0 },
-        { x: 0, y: 1, z: 0 },
-        { x: 1, y: 1, z: 1 },
-        { x: 2, y: 2, z: 1 }
-    ]),
-    new Bezier([
-        { x: 0, y: 1, z: 0 },
-        { x: 0.5, y: 2, z: 1 },
-        { x: 0, y: 3, z: 1 },
-        { x: 0, y: 3, z: 2 }
-    ])
+    {
+        bezier: new Bezier([
+            { x: 0, y: 0, z: 0 },
+            { x: 0, y: 1, z: 0 },
+            { x: 1, y: 1, z: 1 },
+            { x: 2, y: 2, z: 1 }
+        ]),
+        multiplier: GuidingVectors.QUADRATIC
+    },
+    {
+        bezier: new Bezier([
+            { x: 0, y: 1, z: 0 },
+            { x: 0.5, y: 2, z: 1 },
+            { x: 0, y: 3, z: 1 },
+            { x: 0, y: 3, z: 2 }
+        ]),
+        multiplier: GuidingVectors.QUADRATIC
+    }
 ]);
 
 const vectorField = guidingVectors.generateVectorField();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,8 @@ module.exports = {
   devtool: 'inline-source-map',
   entry: {
       app: './src/examples/render.ts',
-      generation: './src/examples/generation.ts'
+      generation: './src/examples/generation.ts',
+      forest: './src/examples/forest.ts'
   },
   output: {
     path: __dirname + '/public',


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/141

This adds a distance cost to each guiding curve in addition to the alignment cost. A distance cost is defined by a multiplier `m: [number, number, number]`. When placing a new piece of structure, `distance` is the distance to the closest point on a guiding curve. For each element `i` in `m`, the cost `m[i] * distance^i` is added. This means `m[0]` adds a constant distance cost, `m[1]` adds a distance cost that increases linearly as you move away from the curve, and `m[2]` adds cost that increases quadratically as you move away from the curve.

In practice, using the `GuidingVectors.NONE` distance multiplier allows you to quickly make a vector field that applies to everything in the scene (e.g. to make a windblown-looking forest, add a single horizontal guiding curve to make all trees in the forest tilt to the side).
<img src="https://user-images.githubusercontent.com/5315059/44318393-a54dda00-a403-11e8-91c2-ec442149087d.png" width="40%" /> <img src="https://user-images.githubusercontent.com/5315059/44318396-a7179d80-a403-11e8-9f4d-dfd33c4e54ad.png" width="40%" />


Using `GuidingVectors.QUADRATIC` makes a shape hug the guiding curve, allowing you to "draw" a shape that will then get procedurally generated.
<img src="https://user-images.githubusercontent.com/5315059/44317392-02935c80-a3ff-11e8-9c2d-0cca1e420018.png" width="30%" /> <img src="https://user-images.githubusercontent.com/5315059/44317394-07581080-a3ff-11e8-9efd-e31e5bdf2da1.png" width="30%" /> <img src="https://user-images.githubusercontent.com/5315059/44317397-0f17b500-a3ff-11e8-8984-f87a2f7c0ca5.png" width="30%" />

## Future work
- ~Generating a forest is surprisingly bad at following the vector field compared to a single tree. We need to investigate why this could be. My current guess is that there are enough spawn points in the forest that there isn't always a good alignment option. Perhaps with supersteps + a sparser initial tree we can remedy this by basically just allowing less spawn points to be sampled in the first step, and then adding detail after.~
- Especially for quadratic falloff, a realtime slider in the editor to change the bezier curves would be great!