### PR TITLE
Add obj exporting capabilities

### DIFF
--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -239,12 +239,10 @@ export class Model {
                 (v: vec3) => `vn ${v[0].toFixed(4)} ${v[1].toFixed(4)} ${v[2].toFixed(4)}`
             ),
 
-            // Turn on smooth shading
-            's 1',
-
             // Create a group for each distinct object, with the proper material applied
             ...flatMap(groups, (g: { indices: number[][]; material: number }, i: number) => [
                 `g group${i}`,
+
                 `usemtl material${g.material}`,
                 ...g.indices.map(
                     (idx: number[]) =>

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -175,6 +175,14 @@ export class Model {
         return { min, max };
     }
 
+    /**
+     * Given an ambient scene colour, this exports a model in a format traditional 3D software
+     * can read.
+     *
+     * @param {Color} ambientLightColor The scene's ambient component, added to materials.
+     * @returns {{obj: string; mtl: string}} The source code for the .obj file for geometry and
+     * the corresponding .mtl file for materials.
+     */
     public exportOBJ(ambientLightColor: Color): { obj: string; mtl: string } {
         const vertices: vec4[] = [];
         const normals: vec3[] = [];

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -177,13 +177,17 @@ export class Model {
 
     /**
      * Given an ambient scene colour, this exports a model in a format traditional 3D software
-     * can read.
+     * can read, the .obj file.
      *
+     * .obj spec: http://paulbourke.net/dataformats/obj/
+     * .mtl spec: http://paulbourke.net/dataformats/mtl/
+     *
+     * @param {string} name The name of the model, onto which .obj and .mtl will be appended.
      * @param {Color} ambientLightColor The scene's ambient component, added to materials.
      * @returns {{obj: string; mtl: string}} The source code for the .obj file for geometry and
      * the corresponding .mtl file for materials.
      */
-    public exportOBJ(ambientLightColor: Color): { obj: string; mtl: string } {
+    public exportOBJ(name: string, ambientLightColor: Color): { obj: string; mtl: string } {
         const vertices: vec4[] = [];
         const normals: vec3[] = [];
         const groups: { indices: number[][]; material: number }[] = [];
@@ -222,10 +226,10 @@ export class Model {
         });
 
         const obj = [
-            'o calderExport',
+            `o ${name}`,
 
             // Source the corresponding material file
-            'mtllib calderExport.mtl',
+            `mtllib ${name}.mtl`,
 
             // List all vertices and normals
             ...vertices.map(
@@ -259,7 +263,10 @@ export class Model {
                 4
             )} ${m.materialColor[2].toFixed(4)}`,
 
-            `Ns ${m.materialShininess.toFixed(4)}`
+            `Ns ${m.materialShininess.toFixed(4)}`,
+
+            // Specify that we want highlights in our illumination model
+            'illum 2'
         ]).join('\n');
 
         return { obj, mtl };

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -246,7 +246,10 @@ export class Model {
             ...flatMap(groups, (g: { indices: number[][]; material: number }, i: number) => [
                 `g group${i}`,
                 `usemtl material${g.material}`,
-                ...g.indices.map((idx: number[]) => `f ${idx[0]} ${idx[1]} ${idx[2]}`)
+                ...g.indices.map(
+                    (idx: number[]) =>
+                        `f ${idx[0]}//${idx[0]} ${idx[1]}//${idx[1]} ${idx[2]}//${idx[2]}`
+                )
             ])
         ].join('\n');
 

--- a/src/armature/Model.ts
+++ b/src/armature/Model.ts
@@ -1,9 +1,14 @@
-import { mat3, mat4, vec4 } from 'gl-matrix';
+import { mat3, mat4, vec3, vec4 } from 'gl-matrix';
 
+import { Color } from '../colors/Color';
 import { AABB } from '../geometry/BakedGeometry';
+import { BakedMaterial } from '../renderer/Material';
+import { RenderObject } from '../types/RenderObject';
 import { worldSpaceAABB } from '../utils/aabb';
 import { GeometryNode, Node } from './Node';
 import { NodeRenderObject } from './NodeRenderObject';
+
+import { chunk, flatMap } from 'lodash';
 
 type RenderInfo = {
     /**
@@ -168,5 +173,87 @@ export class Model {
         );
 
         return { min, max };
+    }
+
+    public exportOBJ(ambientLightColor: Color): { obj: string; mtl: string } {
+        const vertices: vec4[] = [];
+        const normals: vec3[] = [];
+        const groups: { indices: number[][]; material: number }[] = [];
+        const materialIndices: Map<BakedMaterial, number> = new Map<BakedMaterial, number>();
+        const materials: BakedMaterial[] = [];
+
+        this.computeRenderInfo(false).geometry.forEach((r: RenderObject) => {
+            // Give each material a unique number representing it. If a material has already been
+            // given a number, don't add it again, ensuring there are no duplicates.
+            if (!materialIndices.has(r.geometry.material)) {
+                materialIndices.set(r.geometry.material, materials.length);
+                materials.push(r.geometry.material);
+            }
+
+            // Add the vertex indices to a group with the specified material
+            groups.push({
+                // Use an array literal and ... to convert the int16 array to doubles
+                indices: chunk(
+                    [...r.geometry.indices].map((i: number) => i + vertices.length + 1),
+                    3
+                ),
+                material: <number>materialIndices.get(r.geometry.material)
+            });
+
+            // Add vertex and normals, transformed into world space
+            vertices.push(
+                ...chunk(r.geometry.vertices, 3).map(([x, y, z]: number[]) =>
+                    vec4.transformMat4(vec4.create(), vec4.fromValues(x, y, z, 1), r.transform)
+                )
+            );
+            normals.push(
+                ...chunk(r.geometry.normals, 3).map(([x, y, z]: number[]) =>
+                    vec3.transformMat3(vec3.create(), vec3.fromValues(x, y, z), r.normalTransform)
+                )
+            );
+        });
+
+        const obj = [
+            'o calderExport',
+
+            // Source the corresponding material file
+            'mtllib calderExport.mtl',
+
+            // List all vertices and normals
+            ...vertices.map(
+                (v: vec4) => `v ${v[0].toFixed(4)} ${v[1].toFixed(4)} ${v[2].toFixed(4)}`
+            ),
+            ...normals.map(
+                (v: vec3) => `vn ${v[0].toFixed(4)} ${v[1].toFixed(4)} ${v[2].toFixed(4)}`
+            ),
+
+            // Turn on smooth shading
+            's 1',
+
+            // Create a group for each distinct object, with the proper material applied
+            ...flatMap(groups, (g: { indices: number[][]; material: number }, i: number) => [
+                `g group${i}`,
+                `usemtl material${g.material}`,
+                ...g.indices.map((idx: number[]) => `f ${idx[0]} ${idx[1]} ${idx[2]}`)
+            ])
+        ].join('\n');
+
+        const ambient = ambientLightColor.asVec();
+        const mtl = flatMap(materials, (m: BakedMaterial, i: number) => [
+            `newmtl material${i}`,
+            `Ka ${ambient[0].toFixed(4)} ${ambient[1].toFixed(4)} ${ambient[2].toFixed(4)}`,
+
+            // In our shading model, diffuse and specular color are the same
+            `Kd ${m.materialColor[0].toFixed(4)} ${m.materialColor[1].toFixed(
+                4
+            )} ${m.materialColor[2].toFixed(4)}`,
+            `Ks ${m.materialColor[0].toFixed(4)} ${m.materialColor[1].toFixed(
+                4
+            )} ${m.materialColor[2].toFixed(4)}`,
+
+            `Ns ${m.materialShininess.toFixed(4)}`
+        ]).join('\n');
+
+        return { obj, mtl };
     }
 }

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -195,7 +195,7 @@ renderer.eachFrame(draw);
 const exportBtn = document.createElement('button');
 exportBtn.innerText = 'Export .obj';
 exportBtn.addEventListener('click', () => {
-    const obj = tree.exportOBJ(ambientLightColor);
+    const obj = tree.exportOBJ('calderExport', ambientLightColor);
 
     const link = document.createElement('a');
     link.style.display = 'none';

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -15,11 +15,12 @@ import {
 import Bezier = require('bezier-js');
 
 // Create the renderer
+const ambientLightColor = RGBColor.fromRGB(90, 90, 90);
 const renderer: Renderer = new Renderer({
     width: 800,
     height: 600,
     maxLights: 2,
-    ambientLightColor: RGBColor.fromRGB(90, 90, 90),
+    ambientLightColor,
     backgroundColor: RGBColor.fromHex('#FFDDFF')
 });
 
@@ -186,3 +187,30 @@ const draw = () => {
 
 // Apply the constraints each frame.
 renderer.eachFrame(draw);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 4: add .obj export
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+const exportBtn = document.createElement('button');
+exportBtn.innerText = 'Export .obj';
+exportBtn.addEventListener('click', () => {
+    const obj = tree.exportOBJ(ambientLightColor);
+
+    const link = document.createElement('a');
+    link.style.display = 'none';
+    document.body.appendChild(link);
+
+    // Download obj
+    link.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(obj.obj)}`);
+    link.setAttribute('download', 'calderExport.obj');
+    link.click();
+
+    // Download mtl
+    link.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(obj.mtl)}`);
+    link.setAttribute('download', 'calderExport.mtl');
+    link.click();
+
+    document.body.removeChild(link);
+});
+document.body.appendChild(exportBtn);

--- a/src/geometry/Shape.ts
+++ b/src/geometry/Shape.ts
@@ -90,7 +90,14 @@ export namespace Shape {
                 //    X---i+1
                 // The offset is the first index of either the top or the bottom ring.
 
-                faces.push(new Face([offset, offset + i + 1, offset + (i + 1) % PRECISION + 1]));
+                const face = [offset, offset + i + 1, offset + (i + 1) % PRECISION + 1];
+
+                // Ensure proper winding order on top and bottom
+                if (side === 0) {
+                    face.reverse();
+                }
+
+                faces.push(new Face(face));
             });
         });
 

--- a/tests/armature/Model.spec.ts
+++ b/tests/armature/Model.spec.ts
@@ -28,7 +28,9 @@ describe('Model', () => {
             const normals = exported.obj.match(new RegExp('^vn .*$', 'mg'));
             expect(vertices).not.toBeNull();
             expect(normals).not.toBeNull();
-            expect(vertices && vertices.length).toEqual(normals && normals.length);
+            expect(vertices !== null ? vertices.length : 0).toEqual(
+                normals !== null ? normals.length : 0
+            );
 
             const faceRegex = new RegExp('^f (\\d+) (\\d+) (\\d+)$', 'mg');
 
@@ -41,10 +43,10 @@ describe('Model', () => {
                         // Check that faces all refer to real vertices
                         const vertex = parseInt(match[i], 10);
                         expect(vertex).toBeGreaterThan(0);
-                        expect(vertex).toBeLessThanOrEqual(vertices ? vertices.length : 0);
+                        expect(vertex).toBeLessThanOrEqual(vertices !== null ? vertices.length : 0);
                     }
                 }
-            } while (match);
+            } while (match !== null);
 
             // Check that a material was produced
             expect(exported.mtl).toEqual(

--- a/tests/armature/Model.spec.ts
+++ b/tests/armature/Model.spec.ts
@@ -1,10 +1,4 @@
-import {
-    Armature,
-    Model,
-    Node,
-    RGBColor,
-    Shape
-} from '../../src/calder';
+import { Armature, Model, Node, RGBColor, Shape } from '../../src/calder';
 
 const bone = Armature.define((root: Node) => {
     root.createPoint('base', { x: 0, y: 0, z: 0 });
@@ -15,12 +9,19 @@ describe('Model', () => {
     describe('exportOBJ', () => {
         it('generates the expected file for a simple shape', () => {
             const model = Model.create(bone());
-            model.add(model.root().point('base').attach(Shape.sphere()));
+            model.add(
+                model
+                    .root()
+                    .point('base')
+                    .attach(Shape.sphere())
+            );
             const exported = model.exportOBJ('model', RGBColor.fromHex('#000000'));
 
             // Assert that the given name was used for the model and material
             expect(exported.obj).toEqual(expect.stringMatching(new RegExp('^o model', 'm')));
-            expect(exported.obj).toEqual(expect.stringMatching(new RegExp('^mtllib model.mtl', 'm')));
+            expect(exported.obj).toEqual(
+                expect.stringMatching(new RegExp('^mtllib model.mtl', 'm'))
+            );
 
             // Check that there is a vertex normal for every vertex
             const vertices = exported.obj.match(new RegExp('^v .*$', 'mg'));
@@ -46,8 +47,12 @@ describe('Model', () => {
             } while (match);
 
             // Check that a material was produced
-            expect(exported.mtl).toEqual(expect.stringMatching(new RegExp('^newmtl material0$', 'm')));
-            expect(exported.mtl).toEqual(expect.stringMatching(new RegExp('^newmtl material0$', 'm')));
+            expect(exported.mtl).toEqual(
+                expect.stringMatching(new RegExp('^newmtl material0$', 'm'))
+            );
+            expect(exported.mtl).toEqual(
+                expect.stringMatching(new RegExp('^newmtl material0$', 'm'))
+            );
         });
     });
 });

--- a/tests/armature/Model.spec.ts
+++ b/tests/armature/Model.spec.ts
@@ -1,0 +1,53 @@
+import {
+    Armature,
+    Model,
+    Node,
+    RGBColor,
+    Shape
+} from '../../src/calder';
+
+const bone = Armature.define((root: Node) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+});
+
+describe('Model', () => {
+    describe('exportOBJ', () => {
+        it('generates the expected file for a simple shape', () => {
+            const model = Model.create(bone());
+            model.add(model.root().point('base').attach(Shape.sphere()));
+            const exported = model.exportOBJ('model', RGBColor.fromHex('#000000'));
+
+            // Assert that the given name was used for the model and material
+            expect(exported.obj).toEqual(expect.stringMatching(new RegExp('^o model', 'm')));
+            expect(exported.obj).toEqual(expect.stringMatching(new RegExp('^mtllib model.mtl', 'm')));
+
+            // Check that there is a vertex normal for every vertex
+            const vertices = exported.obj.match(new RegExp('^v .*$', 'mg'));
+            const normals = exported.obj.match(new RegExp('^vn .*$', 'mg'));
+            expect(vertices).not.toBeNull();
+            expect(normals).not.toBeNull();
+            expect(vertices && vertices.length).toEqual(normals && normals.length);
+
+            const faceRegex = new RegExp('^f (\\d+) (\\d+) (\\d+)$', 'mg');
+
+            // Iterate over each face
+            let match: string[] | null = null;
+            do {
+                match = faceRegex.exec(exported.obj);
+                if (match !== null) {
+                    for (let i = 1; i <= 3; i += 1) {
+                        // Check that faces all refer to real vertices
+                        const vertex = parseInt(match[i], 10);
+                        expect(vertex).toBeGreaterThan(0);
+                        expect(vertex).toBeLessThanOrEqual(vertices ? vertices.length : 0);
+                    }
+                }
+            } while (match);
+
+            // Check that a material was produced
+            expect(exported.mtl).toEqual(expect.stringMatching(new RegExp('^newmtl material0$', 'm')));
+            expect(exported.mtl).toEqual(expect.stringMatching(new RegExp('^newmtl material0$', 'm')));
+        });
+    });
+});

--- a/tests/armature/Model.spec.ts
+++ b/tests/armature/Model.spec.ts
@@ -32,14 +32,14 @@ describe('Model', () => {
                 normals !== null ? normals.length : 0
             );
 
-            const faceRegex = new RegExp('^f (\\d+) (\\d+) (\\d+)$', 'mg');
+            const faceRegex = new RegExp('^f (\\d+)//(\\d+) (\\d+)//(\\d+) (\\d+)//(\\d+)$', 'mg');
 
             // Iterate over each face
             let match: string[] | null = null;
             do {
                 match = faceRegex.exec(exported.obj);
                 if (match !== null) {
-                    for (let i = 1; i <= 3; i += 1) {
+                    for (let i = 1; i <= 6; i += 1) {
                         // Check that faces all refer to real vertices
                         const vertex = parseInt(match[i], 10);
                         expect(vertex).toBeGreaterThan(0);


### PR DESCRIPTION
A model can now export itself as a `.obj` (and also a `.mtl` with materials.)

Here's a tree in Blender:
![screen shot 2018-08-20 at 10 37 08 am](https://user-images.githubusercontent.com/5315059/44347634-5ab17980-a466-11e8-95cd-400f5210344e.png)

## Future work
- Blender doesn't do smooth shading across a triangle unless the triangle actually shares vertices. Because our sphere generation doesn't do vertex sharing (instead, it just has duplicate vertices), Blender doesn't render our spheres smoothly, even though it really should. So I guess we should look into fixing that.
