### PR TITLE
Add back thick lines when rendering guiding curves

### DIFF
--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -125,15 +125,15 @@ export class GuidingVectors implements CostFn {
      *
      * @returns {Float32Array[]} A vertex buffer for each curve.
      */
-    public generateGuidingCurve(): Float32Array[] {
+    public generateGuidingCurve(): [number, number, number][][] {
         return this.vectors.map((c: GuidingCurve) => {
-            const curve: number[] = [];
+            const curve: [number, number, number][] = [];
 
             c.bezier.getLUT().forEach((p: BezierJs.Point) => {
-                curve.push(p.x, p.y, (<coord>p).z);
+                curve.push([p.x, p.y, (<coord>p).z]);
             });
 
-            return Float32Array.from(curve);
+            return curve;
         });
     }
 

--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -123,7 +123,7 @@ export class GuidingVectors implements CostFn {
     /**
      * For each target curve, creates a vertex buffer of points along the curve.
      *
-     * @returns {Float32Array[]} A vertex buffer for each curve.
+     * @returns {[number, number, number][][]} An array of vertices for each curve.
      */
     public generateGuidingCurve(): [number, number, number][][] {
         return this.vectors.map((c: GuidingCurve) => {

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -292,9 +292,9 @@ export class Renderer {
         window.requestAnimationFrame(draw);
     }
 
-    private drawCurve(curves: Float32Array[]) {
+    private drawCurve(curves: [number, number, number][][]) {
         this.drawGuidingCurve(
-            curves.map((curve: Float32Array) => {
+            curves.map((curve: [number, number, number][]) => {
                 return {
                     cameraTransform: this.camera.getTransform(),
                     projectionMatrix: this.projectionMatrix,

--- a/src/types/DebugParams.ts
+++ b/src/types/DebugParams.ts
@@ -24,5 +24,5 @@ export type DebugParams = {
     /**
      * Draw a guiding curve, represented as an array of points along the curve.
      */
-    drawGuidingCurve?: Float32Array[];
+    drawGuidingCurve?: [number, number, number][][];
 };


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/147

Ok so before, we only rendered guiding curves with a 1px thick line, because not all browsers support thicknesses other than 1 (Chrome! Chrome no longer supports it! Yet Safari does, somehow!)

So, I implemented what is probably going on under the hood anyway. Here's what I wanted to do:

![image](https://user-images.githubusercontent.com/5315059/45592634-c84aab80-b927-11e8-9d1d-659768c03915.png)

1. Take the points making up the curve and put them into screen space
2. Have a second copy of all of the points. (This could be done in a geometry shader, but hey, webgl doesn't have those! so instead I duplicate them on the CPU in javascript.)
3. Push each copy away from the other along the normal. So the direction is just the next point minus the previous point (and I reuse the previous direction for the last point in the line), and then a vector `[x, y]` has the normal `[y, -x]` in 2D space. <a href="https://github.com/calder-gl/calder/blob/master/src/renderer/Renderer.ts#L360">There's a formula</a> to convert the output of the perspective transform to a pixel coordinate, so you can do that in reverse to find out what the magnitude of the offset along the normal should be to end up with 1 pixel on the screen.
4. We then triangulate using these points. There's a webgl setting to draw using a triangle strip, wherein we just pass in the points in order and it triangulates in exactly the way we want, so there isn't any extra effort involved here.


Here's what it looks like now:

<img width="798" alt="screen shot 2018-09-15 at 8 32 13 pm" src="https://user-images.githubusercontent.com/5315059/45592600-f11e7100-b926-11e8-9e43-ec609681a2bc.png">