### PR TITLE
Add funnelling of sample size

### DIFF
--- a/src/armature/Forces.ts
+++ b/src/armature/Forces.ts
@@ -30,7 +30,7 @@ export class Forces implements CostFn {
         });
     }
 
-    public getCost(instance: GeneratorInstance, added: Node[]): Cost {
+    public getCost(instance: GeneratorInstance, added: Node[], _: boolean): Cost {
         // Out of the added nodes, just get the geometry nodes
         const addedGeometry: GeometryNode[] = [];
         added.forEach((n: Node) =>

--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -142,7 +142,7 @@ export class GuidingVectors implements CostFn {
         });
     }
 
-    public getCost(instance: GeneratorInstance, added: Node[]): Cost {
+    public getCost(instance: GeneratorInstance, added: Node[], useHeuristic: boolean): Cost {
         // Out of the added nodes, just get the structure nodes
         const addedStructure: Node[] = [];
         added.forEach((n: Node) =>
@@ -197,14 +197,16 @@ export class GuidingVectors implements CostFn {
         });
 
         let heuristicCost = 0;
-        if (lastClosest !== null) {
-            instance.getSpawnPoints().forEach((spawnPoint: SpawnPoint) => {
-                heuristicCost += this.computeCost(
-                    this.getOrCreateSpawnPointClosest(spawnPoint),
-                    this.getOrCreateSpawnPointVector(instance.generator, spawnPoint),
-                    <vec3>lastLocation
-                );
-            });
+        if (useHeuristic) {
+            if (lastClosest !== null) {
+                instance.getSpawnPoints().forEach((spawnPoint: SpawnPoint) => {
+                    heuristicCost += this.computeCost(
+                        this.getOrCreateSpawnPointClosest(spawnPoint),
+                        this.getOrCreateSpawnPointVector(instance.generator, spawnPoint),
+                        <vec3>lastLocation
+                    );
+                });
+            }
         }
 
         return { realCost: totalCost, heuristicCost };

--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -128,8 +128,7 @@ const tree = treeGen.generateSOSMC({
     sosmcDepth: 200,
     finalDepth: 200,
     samples: 500,
-    initialHeuristicScale: 0.02,
-    finalHeuristicScale: 0.02,
+    heuristicScale: 0.02,
     costFn: guidingVectors
 });
 

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -128,17 +128,24 @@ result.style.display = 'none';
 
 const generationInstances: GeneratorInstance[][] = [];
 
+const start = new Date().getTime();
 const tree = treeGen.generateSOSMC({
     start: 'branch',
     sosmcDepth: 100,
     finalDepth: 100,
-    samples: 100,
+    samples: (generation: number) => 80 - generation / 100 * 70,
+    heuristicScale: (generation: number) => {
+        if (generation <= 50) {
+            return 0.01 - generation / 50 * 0.01;
+        } else {
+            return 0;
+        }
+    },
     costFn: guidingVectors,
-    initialHeuristicScale: 0.01,
-    finalHeuristicScale: 0,
-    finalHeuristicTime: 0.5,
     iterationHook: (instances: GeneratorInstance[]) => generationInstances.push(instances)
 });
+
+const total = (new Date().getTime() - start) / 1000;
 
 result.innerText = '';
 
@@ -154,6 +161,10 @@ generationInstances.forEach((instances: GeneratorInstance[], index: number) => {
 });
 
 document.body.appendChild(result);
+
+const time = document.createElement('p');
+time.innerText = `Generated in ${total.toFixed(4)}s`;
+document.body.appendChild(time);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Step 3: set up renderer

--- a/src/utils/vectors.ts
+++ b/src/utils/vectors.ts
@@ -49,7 +49,7 @@ export function worldSpaceVectors(generator: Generator, start: string): vec4[] {
 
     // Grow ten times to get a range of possibly direct, possibly indirect children
     range(10).forEach(() => {
-        instance.growIfPossible((added: Node[]) => {
+        instance.growIfPossible(false, (added: Node[]) => {
             // Just get the added structure
             const addedStructure: Node[] = [];
             added.forEach((n: Node) =>


### PR DESCRIPTION
Changes in this PR:
- lets heuristic scale be specified as either a number or a function of the current generation
- lets the number of samples be specified as either a number or a function of the current generation
- makes it so that the heuristic cost isn't computed if the heuristic scale is 0