### PR TITLE
Add support for curve selection

### DIFF
--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -110,7 +110,7 @@ treeGen
     .wrapUpMany(['branch', 'maybeBranch', 'branchOrLeaf'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);
 
-const guidingVectors = CostFunction.guidingVectors([
+const curves = [
     {
         bezier: new Bezier([
             { x: 2, y: -1, z: 0 },
@@ -122,9 +122,16 @@ const guidingVectors = CostFunction.guidingVectors([
         alignmentMultiplier: 100,
         alignmentOffset: 0.85
     }
-]);
+];
+const guidingVectors = CostFunction.guidingVectors(curves);
 
-const guidingCurve = guidingVectors.generateGuidingCurve();
+const guidingCurve = guidingVectors.generateGuidingCurve().map((path: [number, number, number][], index: number) => {
+    return {
+        path,
+        selected: false,
+        bezier: curves[index].bezier
+    };
+});
 const vectorField = guidingVectors.generateVectorField(8, 2);
 
 let tree: Model | null = null;

--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -125,13 +125,15 @@ const curves = [
 ];
 const guidingVectors = CostFunction.guidingVectors(curves);
 
-const guidingCurve = guidingVectors.generateGuidingCurve().map((path: [number, number, number][], index: number) => {
-    return {
-        path,
-        selected: false,
-        bezier: curves[index].bezier
-    };
-});
+const guidingCurve = guidingVectors
+    .generateGuidingCurve()
+    .map((path: [number, number, number][], index: number) => {
+        return {
+            path,
+            selected: false,
+            bezier: curves[index].bezier
+        };
+    });
 const vectorField = guidingVectors.generateVectorField(8, 2);
 
 let tree: Model | null = null;

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -128,23 +128,22 @@ const curves = [
 const guidingVectors = CostFunction.guidingVectors(curves);
 
 const vectorField = guidingVectors.generateVectorField();
-const guidingCurves = guidingVectors.generateGuidingCurve().map((path: [number, number, number][], index: number) => {
-    return {
-        path,
-        selected: false,
-        bezier: curves[index].bezier
-    };
-});
+const guidingCurves = guidingVectors
+    .generateGuidingCurve()
+    .map((path: [number, number, number][], index: number) => {
+        return {
+            path,
+            selected: false,
+            bezier: curves[index].bezier
+        };
+    });
 
 renderer.stage.addEventListener('click', (event: MouseEvent) => {
     const boundingRect = renderer.stage.getBoundingClientRect();
-    const selectedIndex = renderer.findCurveUnderCursor(
-        guidingCurves,
-        {
-            x: event.clientX - boundingRect.left,
-            y: event.clientY - boundingRect.top
-        }
-    );
+    const selectedIndex = renderer.findCurveUnderCursor(guidingCurves, {
+        x: event.clientX - boundingRect.left,
+        y: event.clientY - boundingRect.top
+    });
 
     guidingCurves.forEach((curve: GuidingCurveInfo, index: number) => {
         curve.selected = index === selectedIndex;

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -275,14 +275,16 @@ export class Renderer {
         return this.lights;
     }
 
-    public findCurveUnderCursor(curves: GuidingCurveInfo[], cursor: {x: number; y: number}): number | null {
+    public findCurveUnderCursor(
+        curves: GuidingCurveInfo[],
+        cursor: { x: number; y: number }
+    ): number | null {
         let selectedIndex: number | null = null;
 
         // Use an offscreen framebuffer so the user doesn't see any of this happening
         this.pickingFramebuffer.use(() => {
-
             // Clear the buffer to the highest index to represent no curve
-            this.regl.clear({ depth: 1, color: [1, 1, 1, 1] })
+            this.regl.clear({ depth: 1, color: [1, 1, 1, 1] });
 
             // Draw the curves indices to the screen, thicker than usual to increase the
             // size of the clickable region
@@ -306,7 +308,7 @@ export class Renderer {
                 })
             );
 
-            // Read the one pixel from under the 
+            // Read the one pixel from under the
             const data = this.regl.read({
                 x: cursor.x,
                 y: this.height - cursor.y,
@@ -351,9 +353,8 @@ export class Renderer {
         window.requestAnimationFrame(draw);
     }
 
-    public pointInScreenSpace(point: coord): {x: number; y: number} {
-        const point3 = <coord>point;
-        const vector = vec4.set(tmpVec4, point3.x, point3.y, point3.z, 1);
+    public pointInScreenSpace(point: coord): { x: number; y: number } {
+        const vector = vec4.set(tmpVec4, point.x, point.y, point.z, 1);
 
         // Bring the point into camera space
         vec4.transformMat4(vector, vector, this.camera.getTransform());
@@ -365,7 +366,7 @@ export class Renderer {
         const x = (vector[0] / vector[3] + 1) / 2 * this.width;
         const y = (-vector[1] / vector[3] + 1) / 2 * this.height;
 
-        return {x, y};
+        return { x, y };
     }
 
     private drawCurve(curves: GuidingCurveInfo[]) {
@@ -389,7 +390,9 @@ export class Renderer {
 
     private drawSelectedCurveControls(curve: GuidingCurveInfo) {
         const points = curve.bezier.points;
-        const screenSpacePoints = points.map((point: BezierJs.Point) => this.pointInScreenSpace(<coord>point));
+        const screenSpacePoints = points.map((point: BezierJs.Point) =>
+            this.pointInScreenSpace(<coord>point)
+        );
 
         this.ctx2D.fillStyle = '#FFF';
         this.ctx2D.strokeStyle = '#F0F';
@@ -403,10 +406,9 @@ export class Renderer {
             this.ctx2D.stroke();
         });
 
-
         // Draw a circle for the control point handle
         const radius = 3;
-        screenSpacePoints.forEach((point: {x: number; y: number}) => {
+        screenSpacePoints.forEach((point: { x: number; y: number }) => {
             this.ctx2D.beginPath();
             this.ctx2D.arc(point.x, point.y, radius, 0, Math.PI * 2);
             this.ctx2D.stroke();

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -17,6 +17,7 @@ import {
     DrawGuidingCurveProps,
     DrawObjectProps,
     DrawVectorFieldProps,
+    GuidingCurveInfo,
     Light,
     Model,
     Node,
@@ -35,6 +36,9 @@ export type RendererParams = {
     ambientLightColor: Color;
     backgroundColor: Color;
 };
+
+const selectedColor = vec3.fromValues(1, 0, 1);
+const unselectedColor = vec3.fromValues(1, 1, 1);
 
 /**
  * Manages all scene information and is responsible for rendering it to the screen
@@ -57,6 +61,7 @@ export class Renderer {
     private drawGuidingCurve: REGL.DrawCommand<REGL.DefaultContext, DrawGuidingCurveProps>;
     private lights: Light[];
     private ambientLight: vec3;
+    private pickingFramebuffer: REGL.Framebuffer2D;
 
     // Length four array representing an RGBA color
     private backgroundColorArray: [number, number, number, number];
@@ -140,6 +145,8 @@ export class Renderer {
         this.drawAxes = createDrawAxes(this.regl);
         this.drawVectorField = createDrawVectorField(this.regl);
         this.drawGuidingCurve = createDrawGuidingCurve(this.regl);
+
+        this.pickingFramebuffer = this.regl.framebuffer({ width: this.width, height: this.height });
     }
 
     public destroy() {
@@ -265,6 +272,55 @@ export class Renderer {
         return this.lights;
     }
 
+    public findCurveUnderCursor(curves: GuidingCurveInfo[], cursor: {x: number; y: number}): number | null {
+        let selectedIndex: number | null = null;
+
+        // Use an offscreen framebuffer so the user doesn't see any of this happening
+        this.pickingFramebuffer.use(() => {
+
+            // Clear the buffer to the highest index to represent no curve
+            this.regl.clear({ depth: 1, color: [1, 1, 1, 1] })
+
+            // Draw the curves indices to the screen, thicker than usual to increase the
+            // size of the clickable region
+            this.drawGuidingCurve(
+                curves.map((curve: GuidingCurveInfo, index: number) => {
+                    // We want to see which curve is under the mouse pointer, so rather than render
+                    // its actual colour, we want to render its index. This means we need to pack
+                    // the curve index into a colour.
+                    // tslint:disable:no-bitwise
+                    const r = (index & 0xff) / 255;
+                    const g = ((index >> 8) & 0xff) / 255;
+                    const b = ((index >> 16) & 0xff) / 255;
+
+                    return {
+                        cameraTransform: this.camera.getTransform(),
+                        projectionMatrix: this.projectionMatrix,
+                        positions: curve.path,
+                        thickness: 40,
+                        color: vec3.fromValues(r, g, b)
+                    };
+                })
+            );
+
+            // Read the one pixel from under the 
+            const data = this.regl.read({
+                x: cursor.x,
+                y: this.height - cursor.y,
+                width: 1,
+                height: 1
+            });
+
+            // Unpack the colour data from the selected pixel to get an index
+            const readIndex = data[0] + (data[1] << 8) + (data[2] << 16);
+            if (readIndex < curves.length) {
+                selectedIndex = readIndex;
+            }
+        });
+
+        return selectedIndex;
+    }
+
     /**
      * For each frame, the draw callback applies all constraints, and calls
      * `draw` on the objects returned by the callback.
@@ -292,13 +348,15 @@ export class Renderer {
         window.requestAnimationFrame(draw);
     }
 
-    private drawCurve(curves: [number, number, number][][]) {
+    private drawCurve(curves: GuidingCurveInfo[]) {
         this.drawGuidingCurve(
-            curves.map((curve: [number, number, number][]) => {
+            curves.map((curve: GuidingCurveInfo) => {
                 return {
                     cameraTransform: this.camera.getTransform(),
                     projectionMatrix: this.projectionMatrix,
-                    positions: curve
+                    positions: curve.path,
+                    thickness: 8,
+                    color: curve.selected ? selectedColor : unselectedColor
                 };
             })
         );

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -275,6 +275,12 @@ export class Renderer {
         return this.lights;
     }
 
+    /**
+     * @param {GuidingCurveInfo[]} curves The curves to check.
+     * @param {{x: number; y: number}} cursor The location in screen space of the mouse cursor.
+     * @returns {number | null} The index of the guiding curve under the mouse cursor, if there
+     * is one, or null otherwise.
+     */
     public findCurveUnderCursor(
         curves: GuidingCurveInfo[],
         cursor: { x: number; y: number }

--- a/src/renderer/commands/createDrawGuidingCurve.ts
+++ b/src/renderer/commands/createDrawGuidingCurve.ts
@@ -1,4 +1,4 @@
-import { mat4 } from 'gl-matrix';
+import { mat4, vec3 } from 'gl-matrix';
 // tslint:disable-next-line:import-name
 import REGL = require('regl');
 
@@ -12,6 +12,7 @@ interface Uniforms {
     projection: mat4;
     view: mat4;
     thickness: number;
+    color: vec3;
     screenSize: [number, number];
 }
 
@@ -29,6 +30,8 @@ export interface DrawGuidingCurveProps {
     cameraTransform: mat4;
     projectionMatrix: mat4;
     positions: [number, number, number][];
+    thickness: number;
+    color: vec3;
 }
 
 /**
@@ -63,8 +66,10 @@ export function createDrawGuidingCurve(
         frag: `
             precision mediump float;
 
+            uniform vec3 color;
+
             void main() {
-                gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+                gl_FragColor = vec4(color, 1.0);
             }
         `,
         attributes: {
@@ -93,7 +98,8 @@ export function createDrawGuidingCurve(
                 'projectionMatrix'
             ),
             view: regl.prop<DrawGuidingCurveProps, keyof DrawGuidingCurveProps>('cameraTransform'),
-            thickness: 8,
+            thickness: regl.prop<DrawGuidingCurveProps, keyof DrawGuidingCurveProps>('thickness'),
+            color: regl.prop<DrawGuidingCurveProps, keyof DrawGuidingCurveProps>('color'),
             screenSize: (context: REGL.DefaultContext) => [
                 context.viewportWidth,
                 context.viewportHeight

--- a/src/types/DebugParams.ts
+++ b/src/types/DebugParams.ts
@@ -1,3 +1,11 @@
+import 'bezier-js';
+
+export type GuidingCurveInfo = {
+    path: [number, number, number][];
+    selected: boolean;
+    bezier: BezierJs.Bezier;
+}
+
 /*
  * A collection of behaviours in Renderer that enable easier visual debugging of
  * geometry and armatures.
@@ -24,5 +32,5 @@ export type DebugParams = {
     /**
      * Draw a guiding curve, represented as an array of points along the curve.
      */
-    drawGuidingCurve?: [number, number, number][][];
+    drawGuidingCurve?: GuidingCurveInfo[];
 };

--- a/src/types/DebugParams.ts
+++ b/src/types/DebugParams.ts
@@ -4,7 +4,7 @@ export type GuidingCurveInfo = {
     path: [number, number, number][];
     selected: boolean;
     bezier: BezierJs.Bezier;
-}
+};
 
 /*
  * A collection of behaviours in Renderer that enable easier visual debugging of


### PR DESCRIPTION
Now you can click on curves to select them and show their control points!

<img width="816" alt="screen shot 2018-10-07 at 11 56 57 am" src="https://user-images.githubusercontent.com/5315059/46585662-5518ee80-ca28-11e8-9338-f7977d531a76.png">

Here's how this works:
- The shader to draw curves now takes an additional colour as input. For normal rendering, this is just white (or pink if a `selected` flag is true)
- When we're trying to figure out what's under the mouse cursor, we replace the colour with the index of the curve so that each curve has a unique identifier. There's some code to pack the index into a color vec3.
- To see what's under the cursor, render the image to an offscreen buffer, and read the colour at the cursor's position. We can convert the colour value back into an index.

I also draw the control points in the 2D canvas layer because it's easier to do that than draw circles in a shader. I made the method to convert 3D points to screen space points public because I intend to use that in the editor to drag control points.