### PR TITLE
Support drawing a 'pencil' polyline on top of the screen

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -207,6 +207,9 @@ export class Renderer {
         if (debug.drawGuidingCurve !== undefined) {
             this.drawCurve(debug.drawGuidingCurve);
         }
+        if (debug.drawPencilLine !== undefined) {
+            this.drawPencilLine(debug.drawPencilLine);
+        }
         if (debug.drawAxes === true) {
             this.drawCrosshairs();
         }
@@ -420,6 +423,24 @@ export class Renderer {
             this.ctx2D.stroke();
             this.ctx2D.fill();
         });
+    }
+
+    private drawPencilLine(polyline: {x: number; y: number}[]) {
+        if (polyline.length === 0) {
+            return;
+        }
+
+        this.ctx2D.strokeStyle = '#F0F';
+        this.ctx2D.lineWidth = 2;
+
+        this.ctx2D.beginPath();
+        this.ctx2D.moveTo(polyline[0].x, polyline[0].y);
+
+        for (let i = 1; i < polyline.length; i += 1) {
+            this.ctx2D.lineTo(polyline[i].x, polyline[i].y);
+        }
+
+        this.ctx2D.stroke();
     }
 
     private drawField(field: Float32Array) {

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -425,7 +425,7 @@ export class Renderer {
         });
     }
 
-    private drawPencilLine(polyline: {x: number; y: number}[]) {
+    private drawPencilLine(polyline: { x: number; y: number }[]) {
         if (polyline.length === 0) {
             return;
         }

--- a/src/types/DebugParams.ts
+++ b/src/types/DebugParams.ts
@@ -33,4 +33,9 @@ export type DebugParams = {
      * Draw a guiding curve, represented as an array of points along the curve.
      */
     drawGuidingCurve?: GuidingCurveInfo[];
+
+    /**
+     * Draw a line on the screen, represented as a polyline.
+     */
+    drawPencilLine?: {x: number; y: number}[];
 };

--- a/src/types/DebugParams.ts
+++ b/src/types/DebugParams.ts
@@ -37,5 +37,5 @@ export type DebugParams = {
     /**
      * Draw a line on the screen, represented as a polyline.
      */
-    drawPencilLine?: {x: number; y: number}[];
+    drawPencilLine?: { x: number; y: number }[];
 };


### PR DESCRIPTION
This lets you pass an array of points in that will get drawn on top of everything else. The playground will use this when adding new guiding curves.