### PR TITLE
Automatically add nodes to models inside of rule definitions

### DIFF
--- a/src/armature/Generator.ts
+++ b/src/armature/Generator.ts
@@ -256,12 +256,14 @@ export class GeneratorInstance {
             });
         }
 
-        while (this.postSkeletonSpawnPoints.length > 0) {
-            this.growIfPossible(false);
-        }
+        while (this.postSkeletonSpawnPoints.length > 0 || this.hasDecorateCallbacks()) {
+            while (this.postSkeletonSpawnPoints.length > 0) {
+                this.growIfPossible(false);
+            }
 
-        while (this.hasDecorateCallbacks()) {
-            this.runDecorateCallback();
+            while (this.hasDecorateCallbacks()) {
+                this.runDecorateCallback();
+            }
         }
     }
 
@@ -706,14 +708,21 @@ export class Generator {
             });
             yield undefined;
         }
-        while (finalInstance.getPostSkeletonSpawnPoints().length > 0) {
-            finalInstance.growIfPossible(false, false);
-            yield undefined;
-        }
 
-        while (finalInstance.hasDecorateCallbacks()) {
-            finalInstance.runDecorateCallback();
-            yield undefined;
+        // Run this in a loop because decoration callbacks may add post skeleton spawn points
+        while (
+            finalInstance.getPostSkeletonSpawnPoints().length > 0 ||
+            finalInstance.hasDecorateCallbacks()
+        ) {
+            while (finalInstance.getPostSkeletonSpawnPoints().length > 0) {
+                finalInstance.growIfPossible(false, false);
+                yield undefined;
+            }
+
+            while (finalInstance.hasDecorateCallbacks()) {
+                finalInstance.runDecorateCallback();
+                yield undefined;
+            }
         }
 
         yield finalInstance.getModel();

--- a/src/armature/GuidingVectors.ts
+++ b/src/armature/GuidingVectors.ts
@@ -192,7 +192,9 @@ export class GuidingVectors implements CostFn {
 
             // Get the vector between the parent position and the current position
             const vector = vec4.sub(vec4.create(), globalPosition, parentPosition);
-            vec4.normalize(vector, vector);
+            if (vec4.squaredLength(vector) > 0) {
+                vec4.normalize(vector, vector);
+            }
 
             // Find the closest point on a guiding curve
             const closest = this.closest(parentPosition);
@@ -236,9 +238,13 @@ export class GuidingVectors implements CostFn {
         }
 
         // Add cost for vector alignment
-        const alignmentCost =
-            (-vec3.dot(closest.guidingVector, vec3From4(added)) + closest.curve.alignmentOffset) *
-            closest.curve.alignmentMultiplier;
+        let alignmentCost = 0;
+        if (vec4.squaredLength(added) > 0) {
+            alignmentCost =
+                (-vec3.dot(closest.guidingVector, vec3From4(added)) +
+                    closest.curve.alignmentOffset) *
+                closest.curve.alignmentMultiplier;
+        }
 
         return alignmentCost + distanceCost;
     }
@@ -274,7 +280,9 @@ export class GuidingVectors implements CostFn {
             const expectedVector = this.getOrCreateExpectedVector(generator, spawnPoint.component);
             const localToGlobalTransform = spawnPoint.at.node.localToGlobalTransform();
             vector = vec4.transformMat4(vec4.create(), expectedVector, localToGlobalTransform);
-            vec4.normalize(vector, vector);
+            if (vec4.squaredLength(vector) > 0) {
+                vec4.normalize(vector, vector);
+            }
 
             // Cache spawn point direction vector
             this.spawnPointVectors.set(spawnPoint, vector);

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -1011,12 +1011,12 @@ export class Point {
         return geometryNode;
     }
 
-    public attachModel(model: Model): Model {
+    public attachModel(model: Model): Node {
         const clone = model.cloneDeep();
         clone.root().setAnchor(vec3.fromValues(0, 0, 0));
         clone.root().setPosition(Mapper.vectorToCoord(this.position));
         this.node.addChild(clone.root());
 
-        return clone;
+        return clone.root();
     }
 }

--- a/src/armature/Transformation.ts
+++ b/src/armature/Transformation.ts
@@ -17,9 +17,9 @@ export class Transformation {
         rotation: matrix4 = mat4.create(),
         scale: matrix4 = mat4.create()
     ) {
-        this.position = position;
-        this.rotation = rotation;
-        this.scale = scale;
+        this.position = position instanceof Function ? position : vec3.clone(position);
+        this.rotation = rotation instanceof Function ? rotation : mat4.clone(rotation);
+        this.scale = scale instanceof Function ? scale : mat4.clone(scale);
 
         this.matrix = Cache.create(() => {
             const transform = mat4.fromTranslation(mat4.create(), this.getPosition());

--- a/src/examples/benchmark.ts
+++ b/src/examples/benchmark.ts
@@ -36,8 +36,8 @@ const bone = Armature.define((root: Node) => {
 
 const treeGen = Armature.generator();
 treeGen
-    .define('branch', (root: Point, instance: GeneratorInstance) => {
-        const node = instance.add(bone());
+    .define('branch', (root: Point) => {
+        const node = bone();
         node.point('base').stickTo(root);
         node.scale(Math.random() * 0.4 + 0.9);
         node
@@ -50,25 +50,25 @@ treeGen
             .release();
         node.scale(0.8); // Shrink a bit
 
-        const trunk = instance.add(node.point('mid').attach(branchShape));
+        const trunk = node.point('mid').attach(branchShape);
         trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
-        instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+        Generator.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
     })
-    .defineWeighted('branchOrLeaf', 1, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'leaf', at: root });
+    .defineWeighted('branchOrLeaf', 1, (root: Point) => {
+        Generator.addDetail({ component: 'leaf', at: root });
     })
-    .defineWeighted('branchOrLeaf', 4, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
+    .defineWeighted('branchOrLeaf', 4, (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
     })
-    .define('leaf', (root: Point, instance: GeneratorInstance) => {
-        const leaf = instance.add(root.attach(leafSphere));
+    .define('leaf', (root: Point) => {
+        const leaf = root.attach(leafSphere);
         leaf.scale(Math.random() * 0.5 + 0.5);
     })
-    .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
+    .maybe('maybeBranch', (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
     })
     .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);

--- a/src/examples/forest.ts
+++ b/src/examples/forest.ts
@@ -2,7 +2,6 @@ import {
     Armature,
     CostFunction,
     Generator,
-    GeneratorInstance,
     GuidingVectors,
     Light,
     Material,
@@ -63,18 +62,18 @@ const bone = Armature.define((root: Node) => {
 
 const treeGen = Armature.generator();
 treeGen
-    .define('forest', (_: Point, instance: GeneratorInstance) => {
+    .define('forest', (_: Point) => {
         range(15).forEach(() => {
-            const node = instance.add(bone());
+            const node = bone();
             node
                 // Move to random spot in [-8, 8] x [-8, 8] on the ground
                 .moveTo({ x: Math.random() * 16 - 8, y: 0, z: Math.random() * 16 - 8 });
 
-            instance.addDetail({ component: 'branch', at: node.point('base') });
+            Generator.addDetail({ component: 'branch', at: node.point('base') });
         });
     })
-    .define('branch', (root: Point, instance: GeneratorInstance) => {
-        const node = instance.add(bone());
+    .define('branch', (root: Point) => {
+        const node = bone();
         node.point('base').stickTo(root);
         node.scale(Math.random() * 0.4 + 0.9);
         node
@@ -87,25 +86,25 @@ treeGen
             .release();
         node.scale(0.8); // Shrink a bit
 
-        const trunk = instance.add(node.point('mid').attach(branchShape));
+        const trunk = node.point('mid').attach(branchShape);
         trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
-        instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+        Generator.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
     })
-    .defineWeighted('branchOrLeaf', 1, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'leaf', at: root });
+    .defineWeighted('branchOrLeaf', 1, (root: Point) => {
+        Generator.addDetail({ component: 'leaf', at: root });
     })
-    .defineWeighted('branchOrLeaf', 4, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
+    .defineWeighted('branchOrLeaf', 4, (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
     })
-    .define('leaf', (root: Point, instance: GeneratorInstance) => {
-        const leaf = instance.add(root.attach(leafSphere));
+    .define('leaf', (root: Point) => {
+        const leaf = root.attach(leafSphere);
         leaf.scale(Math.random() * 0.5 + 0.5);
     })
-    .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
+    .maybe('maybeBranch', (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
     })
     .wrapUpMany(['branch', 'maybeBranch', 'branchOrLeaf'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -69,8 +69,8 @@ const bone = Armature.define((root: Node) => {
 
 const treeGen = Armature.generator();
 treeGen
-    .define('branch', (root: Point, instance: GeneratorInstance) => {
-        const node = instance.add(bone());
+    .define('branch', (root: Point) => {
+        const node = bone();
         node.point('base').stickTo(root);
         node.scale(Math.random() * 0.4 + 0.9);
         node
@@ -83,30 +83,25 @@ treeGen
             .release();
         node.scale(0.8); // Shrink a bit
 
-        const trunk = instance.add(node.point('mid').attach(branchShape));
+        const trunk = node.point('mid').attach(branchShape);
         trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
-        instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+        Generator.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
     })
-    .defineWeighted('branchOrLeaf', 1, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'leaf', at: root });
+    .defineWeighted('branchOrLeaf', 1, (root: Point) => {
+        Generator.addDetail({ component: 'leaf', at: root });
     })
-    .defineWeighted('branchOrLeaf', 4, (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
-        instance.addDetail({ component: 'maybeBranch', at: root });
+    .defineWeighted('branchOrLeaf', 4, (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
     })
-    .define('leaf', (root: Point, instance: GeneratorInstance) => {
-        const clonedModel = leafModel.cloneDeep();
-        const leaf = clonedModel.root();
-        const nodesToAdd = root.attachModel(leaf, clonedModel.nodes);
-        nodesToAdd.forEach((node: Node) => {
-            instance.add(node);
-        });
-        leaf.scale(Math.random() * 0.5 + 0.5);
+    .define('leaf', (root: Point) => {
+        const leaf = root.attachModel(leafModel);
+        leaf.root().scale(Math.random() * 0.5 + 0.5);
     })
-    .maybe('maybeBranch', (root: Point, instance: GeneratorInstance) => {
-        instance.addDetail({ component: 'branch', at: root });
+    .maybe('maybeBranch', (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
     })
     .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -83,8 +83,10 @@ treeGen
             .release();
         node.scale(0.8); // Shrink a bit
 
-        const trunk = node.point('mid').attach(branchShape);
-        trunk.scale({ x: 0.2, y: 1, z: 0.2 });
+        Generator.decorate(() => {
+            const trunk = node.point('mid').attach(branchShape);
+            trunk.scale({ x: 0.2, y: 1, z: 0.2 });
+        });
 
         Generator.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
     })

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -98,7 +98,7 @@ treeGen
     })
     .define('leaf', (root: Point) => {
         const leaf = root.attachModel(leafModel);
-        leaf.root().scale(Math.random() * 0.5 + 0.5);
+        leaf.scale(Math.random() * 0.5 + 0.5);
     })
     .maybe('maybeBranch', (root: Point) => {
         Generator.addDetail({ component: 'branch', at: root });

--- a/src/examples/render.ts
+++ b/src/examples/render.ts
@@ -78,7 +78,7 @@ const test = Model.create(bone());
 test.root().setPosition({ x: 3, y: 0, z: 0 });
 
 test.root().setScale(Matrix.fromScaling({ x: 1, y: 3, z: 1 }));
-const testChild = test.add(bone());
+const testChild = bone();
 testChild.point('base').stickTo(test.root().point('tip'));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/armature/Generator.spec.ts
+++ b/tests/armature/Generator.spec.ts
@@ -1,5 +1,5 @@
 import { Armature } from '../../src/armature/Armature';
-import { GeneratorInstance } from '../../src/armature/Generator';
+import { Generator } from '../../src/armature/Generator';
 import { Node, Point } from '../../src/armature/Node';
 
 const bone = Armature.define((root: Node) => {
@@ -11,11 +11,11 @@ describe('Generator', () => {
     it('generates to the required depth', () => {
         const towerGen = Armature.generator();
         const tower = towerGen
-            .define('block', (root: Point, instance: GeneratorInstance) => {
-                const node = instance.add(bone());
+            .define('block', (root: Point) => {
+                const node = bone();
                 node.point('base').stickTo(root);
 
-                instance.addDetail({ component: 'block', at: node.point('tip') });
+                Generator.addDetail({ component: 'block', at: node.point('tip') });
             })
             .wrapUp('block', () => {})
             .generate({ start: 'block', depth: 5 });
@@ -26,8 +26,8 @@ describe('Generator', () => {
     it('handles terminal nodes', () => {
         const towerGen = Armature.generator();
         const tower = towerGen
-            .define('block', (root: Point, instance: GeneratorInstance) => {
-                const node = instance.add(bone());
+            .define('block', (root: Point) => {
+                const node = bone();
                 node.point('base').stickTo(root);
 
                 // This definition does not add any more detail


### PR DESCRIPTION
Fixes https://github.com/calder-gl/calder/issues/170

At a high level, this makes it so that inside of rule definitions, you don't need to `instance.add(...)` every node you create; they will be automatically added. Rule definition functions can now just be `(root: Point) => void` instead of `(root: Point, instance: GeneratorInstance) => void`. `instance.addDetail` is now `Generator.addDetail`.

This works by storing essentially a global variable for the current generator instance context, and having `Node` automatically add itself to that, if it exists.