### PR TITLE
Catch errors in draw() so requestAnimationFrame is always called

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -376,15 +376,22 @@ export class Renderer {
      */
     public eachFrame(drawCallback: () => RenderParams) {
         const draw = () => {
-            const { objects, debugParams } = drawCallback();
-            Animation.tick();
-            Constraints.getInstance().applyAll();
-            this.draw(
-                objects,
-                debugParams !== undefined
-                    ? debugParams
-                    : { drawAxes: false, drawArmatureBones: false }
-            );
+            try {
+                const { objects, debugParams } = drawCallback();
+                Animation.tick();
+                Constraints.getInstance().applyAll();
+                this.draw(
+                    objects,
+                    debugParams !== undefined
+                        ? debugParams
+                        : { drawAxes: false, drawArmatureBones: false }
+                );
+            } catch (e) {
+                // Log errors, but make sure requestAnimationFrame gets
+                // called again.
+                // tslint:disable-next-line:no-console
+                console.log(e);
+            }
 
             // Your callback routine must itself call requestAnimationFrame() if
             // you want to animate another frame at the next repaint.


### PR DESCRIPTION
If an error happened in `draw()` (e.g. if you made an uninvertible transformation) then code execution stops before `requestAnimationFrame` is called, meaning the renderer stops trying to draw anything from that point onwards, even if you were to fix your error in the playground and try to rerun.

This puts a try/catch in `draw()` so that errors are still logged but that the renderer never stops trying to run every frame.