### PR TITLE
Create an incentive for having bones use every guide

### DIFF
--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -114,8 +114,19 @@ const curves = [
         bezier: new Bezier([
             { x: 0, y: 0, z: 0 },
             { x: 0, y: 1, z: 0 },
-            { x: 1, y: 1, z: 1 },
-            { x: 2, y: 2, z: 1 }
+            { x: 1, y: 1, z: -1 },
+            { x: 2, y: 2, z: -1 }
+        ]),
+        distanceMultiplier: scale,
+        alignmentMultiplier: 400,
+        alignmentOffset: 0.6
+    },
+    {
+        bezier: new Bezier([
+            { x: 1.5, y: 2, z: -1 },
+            { x: 1.5, y: 2.25, z: -1 },
+            { x: 1.5, y: 2.75, z: -1 },
+            { x: 1.5, y: 3, z: -1 }
         ]),
         distanceMultiplier: scale,
         alignmentMultiplier: 400,


### PR DESCRIPTION
This adds an incentive for all guides being used, instead of sticking to just one of them. Here's what it does:

- It adds an initial cost per guide
- As each guide gets used, it removes that cost

Note that if the initial cost per guide is set to 0, the behaviour should be the same as we had before.

For a guide to be "used", it just needs to be the closest guide to a given bone. This does not say anything about how far away it is or how well aligned it is, so if the incentive is made too large, you can get models that don't look anything like the guides but do overlap with them.

The effect is supposed to be subtle, and hopefully increase the amount of time that all the guides are used. TODO: run a bunch of times with an incentive of 0 and with an incentive of e.g. 100 and see just how much that probability changes.