### PR TITLE
Add SOSMC example figure, update bones to match cost fn definition

### DIFF
--- a/examples/sosmc.html
+++ b/examples/sosmc.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>SOSMC example</title>
+  </head>
+  <body>
+    <script type="text/javascript" src="../public/build/sosmc.js"></script>
+  </body>
+</html>

--- a/src/armature/Node.ts
+++ b/src/armature/Node.ts
@@ -532,11 +532,9 @@ export class Node {
 
         const objects: NodeRenderObject = { geometry: [], bones: [] };
 
-        if (makeBones) {
+        if (this.parent !== null && makeBones) {
             objects.bones.push(
-                ...Object.keys(this.points).map((name: string): RenderObject =>
-                    this.boneRenderObject(this.points[name], currentMatrix, currentNormalMatrix)
-                )
+                this.boneRenderObject(this.getPosition(), parentMatrix, parentNormalMatrix)
             );
         }
 
@@ -546,7 +544,7 @@ export class Node {
     /**
      * Create a RenderObject visualizing this armature node relative to its parent.
      *
-     * @param {Point} point The point to make a bone for.
+     * @param {vec3} point The point to make a bone for.
      * @param {mat4} currentMatrix A matrix to translate points into the coordinate space of the
      * current node.
      * @param {mat3} currentNormalMatrix A matrix to transform normals into the current node's
@@ -555,7 +553,7 @@ export class Node {
      * to the current node's origin.
      */
     protected boneRenderObject(
-        point: Point,
+        point: vec3,
         currentMatrix: mat4,
         currentNormalMatrix: mat3
     ): RenderObject {
@@ -569,14 +567,14 @@ export class Node {
                 quat.rotationTo(
                     quat.create(),
                     vec3.fromValues(1, 0, 0),
-                    vec3.normalize(vec3.create(), point.position)
+                    vec3.normalize(vec3.create(), point)
                 )
             ),
 
             // If you have a point that is also at the root of the node, then the bone
             // connecting them has length 0 and its transformation matrix can't be inverted. This
             // `max` is to make sure the bone doesn't entirely disappear into two dimensions.
-            vec3.fromValues(Math.max(1e-6, vec3.length(point.position)), 1, 1)
+            vec3.fromValues(Math.max(1e-6, vec3.length(point)), 1, 1)
         );
         const transformationMatrix = mat4.create();
         mat4.multiply(transformationMatrix, currentMatrix, transform);
@@ -916,19 +914,19 @@ export class GeometryNode extends Node {
      * transformations multiplied by the `coordinateSpace` parameter.
      *
      * @param {mat4} coordinateSpace The coordinate space this node resides in.
-     * @param {boolean} makeBones Whether or not the armature heirarchy should be visualized.
+     * @param {boolean} _makeBones Whether or not the armature heirarchy should be visualized.
      * @returns {NodeRenderObject} The geometry for this armature subtree, and possibly geometry
      * representing the armature itself.
      */
     public computeRenderInfo(
         coordinateSpace: mat4,
         normalTransform: mat3,
-        makeBones: boolean
+        _makeBones: boolean
     ): { currentMatrix: mat4; currentNormalMatrix: mat3; objects: NodeRenderObject } {
         const { currentMatrix, currentNormalMatrix, objects } = super.computeRenderInfo(
             coordinateSpace,
             normalTransform,
-            makeBones
+            false
         );
         objects.geometry.push({
             geometry: this.geometry,

--- a/src/examples/sosmc.ts
+++ b/src/examples/sosmc.ts
@@ -1,0 +1,230 @@
+import {
+    Armature,
+    CostFunction,
+    Generator,
+    GeneratorInstance,
+    GeometryNode,
+    Light,
+    Material,
+    Model,
+    Node,
+    Point,
+    Renderer,
+    RGBColor,
+    Shape
+} from '../calder';
+
+// tslint:disable-next-line:import-name
+import Bezier = require('bezier-js');
+
+// Create the renderer
+const ambientLightColor = RGBColor.fromRGB(90, 90, 90);
+const renderer: Renderer = new Renderer({
+    width: 500,
+    height: 400,
+    maxLights: 2,
+    ambientLightColor,
+    backgroundColor: RGBColor.fromHex('#FFDDFF')
+});
+
+// Create light sources for the renderer
+const light1: Light = Light.create({
+    position: { x: 10, y: 10, z: 10 },
+    color: RGBColor.fromHex('#FFFFFF'),
+    strength: 200
+});
+
+// Add lights to the renderer
+renderer.addLight(light1);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 1: create geometry
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Setup leaf
+const leafColor = RGBColor.fromRGB(204, 255, 204);
+const leafSphere: Node = new GeometryNode(
+    Shape.sphere(Material.create({ color: leafColor, shininess: 100 }))
+);
+const leafModel = new Model([leafSphere]);
+
+// Setup branch
+const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
+const branchShape = Shape.cylinder(Material.create({ color: branchColor, shininess: 1 }));
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 2: create armature
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+const bone = Armature.define((root: Node) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', { x: 1, y: 0, z: 0 });
+});
+
+const treeGen = Armature.generator();
+treeGen
+    .define('branch', (root: Point) => {
+        const node = bone();
+        node.point('base').stickTo(root);
+        node.scale(Math.random() * 0.4 + 0.9);
+        node
+            .hold(node.point('tip'))
+            .rotate(Math.random() * 360)
+            .release();
+        node
+            .hold(node.point('handle'))
+            .rotate(Math.random() * 70)
+            .release();
+        node.scale(0.8); // Shrink a bit
+
+        Generator.decorate(() => {
+            const trunk = node.point('mid').attach(branchShape);
+            trunk.scale({ x: 0.2, y: 1, z: 0.2 });
+        });
+
+        Generator.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+    })
+    .defineWeighted('branchOrLeaf', 1, (root: Point) => {
+        Generator.addDetail({ component: 'leaf', at: root });
+    })
+    .defineWeighted('branchOrLeaf', 4, (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
+        Generator.addDetail({ component: 'maybeBranch', at: root });
+    })
+    .define('leaf', (root: Point) => {
+        const leaf = root.attachModel(leafModel);
+        leaf.scale(0.7);
+    })
+    .maybe('maybeBranch', (root: Point) => {
+        Generator.addDetail({ component: 'branch', at: root });
+    })
+    .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
+    .thenComplete(['leaf']);
+
+const scale: [number, number, number] = [0, 0, 100];
+const curves = [
+    {
+        bezier: new Bezier([
+            { x: 0, y: 0, z: 0 },
+            { x: 0, y: 1, z: 0 },
+            { x: 1, y: 2, z: 0 },
+            { x: 2, y: 2.5, z: 0 }
+        ]),
+        distanceMultiplier: scale,
+        alignmentMultiplier: 600,
+        alignmentOffset: 0.7
+    }
+];
+const guidingVectors = CostFunction.guidingVectors(curves);
+
+const guidingCurves = guidingVectors
+    .generateGuidingCurve()
+    .map((path: [number, number, number][], index: number) => {
+        return {
+            path,
+            selected: true,
+            bezier: curves[index].bezier
+        };
+    });
+
+const result = document.createElement('p');
+result.style.display = 'none';
+
+const generationInstances: GeneratorInstance[][] = [];
+
+const showBones = document.createElement('p');
+showBones.innerText = 'Show bones? ';
+const drawArmatureBones = document.createElement('input');
+drawArmatureBones.setAttribute('type', 'checkbox');
+drawArmatureBones.checked = true;
+showBones.appendChild(drawArmatureBones);
+
+const showCurves = document.createElement('p');
+showCurves.innerText = 'Show guides? ';
+const drawGuidingCurves = document.createElement('input');
+drawGuidingCurves.setAttribute('type', 'checkbox');
+drawGuidingCurves.checked = true;
+showCurves.appendChild(drawGuidingCurves);
+
+const row = document.createElement('div');
+row.setAttribute('style', 'display: flex;');
+
+let tree: Model | null = null;
+treeGen
+    .generateSOSMC(
+        {
+            start: 'branch',
+            sosmcDepth: 20,
+            samples: (_: number) => 10,
+            heuristicScale: (generation: number) => {
+                return 0.01 - generation / 20 * 0.01;
+            },
+            costFn: guidingVectors,
+            iterationHook: (instances: GeneratorInstance[]) => {
+                generationInstances.push(instances);
+            }
+        },
+        1 / 30
+    )
+    .then(() => {
+        tree = generationInstances[0][0].getModel();
+
+        const container = document.createElement('div');
+        container.setAttribute('style', 'flex: 1; height: 600px; overflow-y: auto;');
+
+        const buttons = document.createElement('div');
+
+        generationInstances.forEach((instances: GeneratorInstance[], round: number) => {
+            const group = document.createElement('p');
+            group.innerText = `Round ${round + 1}`;
+
+            instances.forEach((instance: GeneratorInstance, index: number) => {
+                // Add more than just bones
+                instance.finishGeneration();
+
+                // Make a button to toggle its visibility
+                const button = document.createElement('button');
+                button.innerText = `${index + 1}`;
+                button.addEventListener('click', () => (tree = instance.getModel()));
+                group.appendChild(button);
+            });
+            buttons.appendChild(group);
+        });
+
+        container.appendChild(showBones);
+        container.appendChild(showCurves);
+        container.appendChild(buttons);
+        row.appendChild(container);
+    });
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 3: set up renderer
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+row.appendChild(renderer.stage);
+document.body.appendChild(row);
+
+renderer.camera.lookAt({ x: 0, y: 1, z: 0 });
+renderer.camera.moveToWithFixedTarget({
+    x: 0,
+    y: 1,
+    z: 6
+});
+
+// Draw the armature
+const draw = () => {
+    return {
+        objects: tree === null ? [] : [tree],
+        debugParams: {
+            drawAxes: false,
+            drawArmatureBones: !!drawArmatureBones.checked,
+            drawGuidingCurve: drawGuidingCurves.checked ? guidingCurves : undefined
+        }
+    };
+};
+
+// Apply the constraints each frame.
+renderer.eachFrame(draw);

--- a/src/renderer/Material.ts
+++ b/src/renderer/Material.ts
@@ -61,6 +61,6 @@ export class Material implements Bakeable {
 }
 
 export const defaultMaterial: Material = Material.create({
-    color: RGBColor.fromHex('#EEEEEE'),
+    color: RGBColor.fromHex('#FFFFFF'),
     shininess: 1
 });

--- a/tests/armature/Node.spec.ts
+++ b/tests/armature/Node.spec.ts
@@ -596,38 +596,33 @@ describe('Node', () => {
             const root = bone();
             root.scale(2);
 
-            /**
-             * The bone should start at the root position (0, 0, 0) and stretch to the base of the
-             * geometry node (1, 1, 0). Here we create a point representing the base of the bone
-             * (which is (0, 0, 0) in its relative coordinate space) and the tip of the bone (which
-             * is (1, 0, 0)), and the expected positions for these points in world space so that we
-             * can assert that the endpoints get transformed to the expected world space points.
-             */
+            // There should not be bones when there is only one node
+            expect(Model.create(root).computeRenderInfo(true).bones.length).toBe(0);
+
+            const child = bone();
+            child.point('base').stickTo(root.point('tip'));
+
+            // There should be a bone now that there is a child
+            const bones = Model.create(root, child).computeRenderInfo(true).bones;
+            expect(bones.length).toBe(1);
+
+            // In its their own coordinate space, bones always have a length of 1, along
+            // the x axis
             const boneSpaceBase = vec4.fromValues(0, 0, 0, 1);
             const boneSpaceTip = vec4.fromValues(1, 0, 0, 1);
 
+            // Since the root is scaled, in world space, the bone should have a length of 2,
+            // and should be oriented vertically
             const expectedWorldSpaceBase = vec4.fromValues(0, 0, 0, 1);
             const expectedWorldSpaceTip = vec4.fromValues(0, 2, 0, 1);
 
-            const bones: RenderObject[] = Model.create(root).computeRenderInfo(true).bones;
-            expect(bones.length).toBe(2);
-
-            // Check base and tip of bone 1
+            // Check base and tip of the bone
             const transformedBase = vec4.create();
             vec4.transformMat4(transformedBase, boneSpaceBase, bones[0].transform);
             expect(transformedBase).toEqualVec4(expectedWorldSpaceBase);
 
             const transformedTip = vec4.create();
             vec4.transformMat4(transformedTip, boneSpaceTip, bones[0].transform);
-            expect(transformedTip).toEqualVec4(
-                vec4.add(vec4.create(), expectedWorldSpaceBase, vec4.fromValues(1e-6, 0, 0, 0))
-            );
-
-            // Check base and tip of bone 2
-            vec4.transformMat4(transformedBase, boneSpaceBase, bones[1].transform);
-            expect(transformedBase).toEqualVec4(expectedWorldSpaceBase);
-
-            vec4.transformMat4(transformedTip, boneSpaceTip, bones[1].transform);
             expect(transformedTip).toEqualVec4(expectedWorldSpaceTip);
         });
     });

--- a/tslint.json
+++ b/tslint.json
@@ -29,6 +29,7 @@
     "prefer-method-signature": false,
     "no-empty": false,
     "no-unnecessary-qualifier": false,
+    "variable-name": false,
     "typedef": [
       true,
       "parameter",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
       silhouette: './src/examples/silhouette.ts',
       forest: './src/examples/forest.ts',
       benchmark: './src/examples/benchmark.ts',
-      mutation: './src/examples/mutation.ts'
+      mutation: './src/examples/mutation.ts',
+      sosmc: './src/examples/sosmc.ts'
   },
   output: {
     path: __dirname + '/public',


### PR DESCRIPTION
For the poster, I wanted to be able to make a diagram like this:

<img width="606" alt="screen shot 2019-02-11 at 11 28 45 am" src="https://user-images.githubusercontent.com/5315059/52577484-3371ae80-2df0-11e9-9c95-9d5e967cee32.png">

To do so, I made an example file that uses the generator's `iterationHook` to get the models from each round, and adds buttons to view them all so that I can grab screenshots and make a diagram.

I also needed to update the bones to match our definition in the paper. Previously, bones went from the root of a node to each defined point in the node. Now, it goes from the root of a node to its parent's root. Geometry nodes do not render bones.