### PR TITLE
Guide utilization as incentive

### DIFF
--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -108,7 +108,7 @@ treeGen
     .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);
 
-const scale: [number, number, number] = [0, 0, 100];
+const scale: [number, number, number] = [0, 0, 300];
 const curves = [
     {
         bezier: new Bezier([

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -108,7 +108,7 @@ treeGen
     .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
     .thenComplete(['leaf']);
 
-const scale: [number, number, number] = [0, 0, 300];
+const scale: [number, number, number] = [0, 0, 150];
 const curves = [
     {
         bezier: new Bezier([
@@ -118,8 +118,8 @@ const curves = [
             { x: 2, y: 2, z: -1 }
         ]),
         distanceMultiplier: scale,
-        alignmentMultiplier: 400,
-        alignmentOffset: 0.6
+        alignmentMultiplier: 300,
+        alignmentOffset: 0.8
     },
     {
         bezier: new Bezier([
@@ -129,8 +129,8 @@ const curves = [
             { x: 1.5, y: 3, z: -1 }
         ]),
         distanceMultiplier: scale,
-        alignmentMultiplier: 400,
-        alignmentOffset: 0.6
+        alignmentMultiplier: 300,
+        alignmentOffset: 0.8
     },
     {
         bezier: new Bezier([
@@ -229,11 +229,11 @@ renderer.camera.lookAt({ x: 0, y: 1, z: 0 });
 // Draw the armature
 let angle = 0;
 const draw = () => {
-    angle += 0.001;
+    angle += 0.005;
     renderer.camera.moveToWithFixedTarget({
-        x: Math.cos(angle) * 8,
+        x: Math.cos(angle) * 12,
         y: 1,
-        z: -Math.sin(angle) * 8
+        z: -Math.sin(angle) * 12
     });
     //tree.root().setRotation(Matrix.fromQuat4(Quaternion.fromEuler(0, angle, 0)));
 

--- a/src/examples/generation.ts
+++ b/src/examples/generation.ts
@@ -114,8 +114,19 @@ const curves = [
         bezier: new Bezier([
             { x: 0, y: 0, z: 0 },
             { x: 0, y: 1, z: 0 },
-            { x: 1, y: 1, z: 1 },
-            { x: 2, y: 2, z: 1 }
+            { x: 1, y: 1, z: -1 },
+            { x: 2, y: 2, z: -1 }
+        ]),
+        distanceMultiplier: scale,
+        alignmentMultiplier: 400,
+        alignmentOffset: 0.6
+    },
+    {
+        bezier: new Bezier([
+            { x: 1.5, y: 2, z: -1 },
+            { x: 1.5, y: 2.25, z: -1 },
+            { x: 1.5, y: 2.75, z: -1 },
+            { x: 1.5, y: 3, z: -1 }
         ]),
         distanceMultiplier: scale,
         alignmentMultiplier: 400,


### PR DESCRIPTION
Changes made for this to happen:
- Each guide is given a segment per ~0.2 units of length
- When a bone's cost is calculated according to the guide closest to the bone base:
  - Also find the point closest to the bone's tip
  - Find the bins between the point closest to the base and the tip
  - Increment each by 1
  - Add a negative cost for each bin where each usage of the bin gets an exponentially decreasing bonus

Each instance keeps track of these counts using a `number[][]` where `[i][j]` refers to the `j`th segment of guide `i`.